### PR TITLE
Output format mismatch between format of write_file() and the regex in load_file_into_tree()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name="sops",
     py_modules=['sops'],
-    version="1.6",
+    version="1.7",
     author="Julien Vehent",
     author_email="jvehent@mozilla.com",
     description="Secrets OPerationS (sops) is an editor of encrypted files",

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -401,7 +401,7 @@ def load_file_into_tree(path, filetype, restore_sops=None):
                 if "version" not in tree['sops']:
                     tree['data'] = data
             except:
-                tree = dict()
+                tree = OrderedDict()
                 valre = b'(.+)^SOPS=({.+})$'
                 res = re.match(valre, data, flags=(re.MULTILINE | re.DOTALL))
                 if res is None:

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -38,7 +38,7 @@ else:
 if sys.version_info[0] == 3:
     raw_input = input
 
-VERSION = 1.6
+VERSION = 1.7
 
 DESC = """
 `sops` supports AWS KMS and PGP encryption:

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -1077,6 +1077,10 @@ def write_file(tree, path=None, filetype=None):
                     sys.stdout.write(tree['data'].decode('utf-8'))
                 else:
                     fd.write(tree['data'])
+            if path == 'stdout':
+                sys.stdout.write("\n")
+            else:
+                fd.write("\n")
         if 'sops' in tree:
             jsonstr = json.dumps(tree['sops'], sort_keys=True)
             if path == 'stdout':

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -401,6 +401,7 @@ def load_file_into_tree(path, filetype, restore_sops=None):
                 if "version" not in tree['sops']:
                     tree['data'] = data
             except:
+                tree = dict()
                 valre = b'(.+)^SOPS=({.+})$'
                 res = re.match(valre, data, flags=(re.MULTILINE | re.DOTALL))
                 if res is None:


### PR DESCRIPTION
The non-structured input type default expects data to match this regex in `load_file_into_tree()`:

```
                valre = b'(.+)^SOPS=({.+})$'
```

However, the output format in `write_file()` does not add a \n after data, so SOPS is appended to `ENC[]` and causes an error when attempting to decrypt.

Steps to reproduce:
```
bash-3.2$ echo 'This is a textfile' > passwords.txt
bash-3.2$ sops -i -e --output-type blob passwords.txt
please wait while a data encryption key is being generated and stored securely
bash-3.2$ sops -d passwords.txt
PANIC: could not retrieve a key to encrypt/decrypt the tree
bash-3.2$ cat passwords.txt
ENC[AES256_GCM,data:<...>,type:str]SOPS={"attention": "This section contains key material that should only be modified with extra care. See `sops -h`.", "kms": <...>
```

The attached patch explicitly adds a \n after data so the output can now be parsed by `load_file_into_tree()`:

```
ENC[AES256_GCM,data:<...>,type:str]
SOPS={"attention": "This section contains key material that should only be modified with extra care. See `sops -h`.", "kms": <...>
```