### PR TITLE
Output format mismatch between format of write_file() and the regex in load_file_into_tree()

### DIFF
--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -1130,6 +1130,10 @@ def write_file(tree, path=None, filetype=None):
                     sys.stdout.write(tree['data'].decode('utf-8'))
                 else:
                     fd.write(tree['data'])
+            if path == 'stdout':
+                sys.stdout.write("\n")
+            else:
+                fd.write("\n")
         if 'sops' in tree:
             jsonstr = json.dumps(tree['sops'], sort_keys=True)
             if path == 'stdout':


### PR DESCRIPTION
The non-structured input type default expects data to match this regex in `load_file_into_tree()`:

```
                valre = b'(.+)^SOPS=({.+})$'
```

However, the output format in `write_file()` does not add a \n after data, so SOPS is appended to `ENC[]` and causes an error when attempting to decrypt.

Steps to reproduce:
```
bash-3.2$ echo 'This is a textfile' > passwords.txt
bash-3.2$ sops -i -e --output-type blob passwords.txt
please wait while a data encryption key is being generated and stored securely
bash-3.2$ sops -d passwords.txt
PANIC: could not retrieve a key to encrypt/decrypt the tree
bash-3.2$ cat passwords.txt
ENC[AES256_GCM,data:<...>,type:str]SOPS={"attention": "This section contains key material that should only be modified with extra care. See `sops -h`.", "kms": <...>
```

The attached patch explicitly adds a \n after data so the output can now be parsed by `load_file_into_tree()`:

```
ENC[AES256_GCM,data:<...>,type:str]
SOPS={"attention": "This section contains key material that should only be modified with extra care. See `sops -h`.", "kms": <...>
```