### PR TITLE
sops --input-type load exception allows tree to be initialized as list, not OrderedDict

### DIFF
--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -419,6 +419,7 @@ def load_file_into_tree(path, filetype, restore_sops=None):
                 if "version" not in tree['sops']:
                     tree['data'] = data
             except:
+                tree = OrderedDict()
                 valre = b'(.+)^SOPS=({.+})$'
                 res = re.match(valre, data, flags=(re.MULTILINE | re.DOTALL))
                 if res is None:


### PR DESCRIPTION
[Resubmitted from a branch from my checkout]

Somewhat related to the issue discussed in https://github.com/mozilla/sops/issues/39. When --input-type is anything other than json/yaml it still tries to load the input as json, which can except. If it does except in some cases `tree` can be initialized as a list instead of a dict.

```
bash-3.2$ cat test.txt
[
]
bash-3.2$ sops --input-type blob --output-type json -e test.txt
Traceback (most recent call last):
  File "/usr/local/bin/sops", line 9, in <module>
    load_entry_point('sops==1.6', 'console_scripts', 'sops')()
  File "/Library/Python/2.7/site-packages/sops/__init__.py", line 194, in main
    pgp_fps=pgp_fps)
  File "/Library/Python/2.7/site-packages/sops/__init__.py", line 353, in initialize_tree
    tree = load_file_into_tree(path, itype)
  File "/Library/Python/2.7/site-packages/sops/__init__.py", line 407, in load_file_into_tree
    tree['data'] = data
TypeError: list indices must be integers, not unicode
bash-3.2$
```

Explicitly initializing `tree` seems to fix this, but I'm not sure if it's the best way. Discussion welcome.