### PR TITLE
Support for configuration file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -292,12 +292,11 @@ Let's take an example:
 
 * file named **something.dev.yaml** should use one set of KMS A
 * file named **something.prod.yaml** should use another set of KMS B
-* all other files use a third set of KMS C
-* All live under **mysecretrepo/something.{dev,prod}.yaml**
+* other files use a third set of KMS C
+* all live under **mysecretrepo/something.{dev,prod}.yaml**
 
-Under those circumstances, a configuration file placed at
-**mysecretrepo/.sops.yaml** can drive the two sets of KMS used for the two types
-of files.
+Under those circumstances, a file placed at **mysecretrepo/.sops.yaml**
+can manage the three sets of configurations for the three types of files:
 
 .. code:: yaml
 
@@ -323,7 +322,7 @@ of files.
 When creating any file under **mysecretrepo**, whether at the root or under
 a subdirectory, sops will recursively look for a `.sops.yaml` file. If one is
 found, the filename of the file being created is compared with the filename
-patterns of the configuration file. The first pattern that matches is selected,
+regexes of the configuration file. The first regex that matches is selected,
 and its KMS and PGP keys are used to encrypt the file.
 
 Creating a new file with the right keys is now as simple as

--- a/README.rst
+++ b/README.rst
@@ -280,8 +280,8 @@ KMS and PGP master keys defined in the file.
 
 	sops -r example.yaml
 
-Automating KMS/PGP configuration of new files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using .sops.yaml conf to select KMS/PGP for new files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is often tedious to specify the `--kms` and `--pgp` parameters for creation
 of all new files. If your secrets are stored under a specific directory, like a
@@ -289,10 +289,11 @@ of all new files. If your secrets are stored under a specific directory, like a
 directory to define which keys are used for which filename.
 
 Let's take an example:
+
 * file named **something.dev.yaml** should use one set of KMS A
 * file named **something.prod.yaml** should use another set of KMS B
 * all other files use a third set of KMS C
-* All live under **mysecretrepo/somethind.{dev,prod}.yaml**
+* All live under **mysecretrepo/something.{dev,prod}.yaml**
 
 Under those circumstances, a configuration file placed at
 **mysecretrepo/.sops.yaml** can drive the two sets of KMS used for the two types
@@ -304,19 +305,19 @@ of files.
 	creation_rules:
 		# upon creation of a file that matches the pattern *.dev.yaml,
 		# KMS set A is used
-		- filename_pattern: \.dev\.yaml$
+		- filename_regex: \.dev\.yaml$
 		  kms: 'arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500,arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e+arn:aws:iam::361527076523:role/hiera-sops-prod'
 		  pgp: '1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A'
 
 		# prod files use KMS set B in the PROD IAM
-		- filename_pattern: \.prod\.yaml$
+		- filename_regex: \.prod\.yaml$
 		  kms: 'arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e+arn:aws:iam::361527076523:role/hiera-sops-prod,arn:aws:kms:eu-central-1:361527076523:key/cb1fab90-8d17-42a1-a9d8-334968904f94+arn:aws:iam::361527076523:role/hiera-sops-prod'
 		  pgp: '1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A'
 
 		# Finally, if the rules above have not matched, this one is a 
 		# catchall that will encrypt the file using KMS set C
-		- filename_pattern: .+
-		  kms: 'arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500,arn:aws:kms:us-west-2:142069644989:key/846cfb17-373d-49b9-8baf-f36b04512e47,arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e'
+		# The absence of a filename_regex means it will match everything
+		- kms: 'arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500,arn:aws:kms:us-west-2:142069644989:key/846cfb17-373d-49b9-8baf-f36b04512e47,arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e'
 		  pgp: '1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A'
 
 When creating any file under **mysecretrepo**, whether at the root or under
@@ -324,6 +325,15 @@ a subdirectory, sops will recursively look for a `.sops.yaml` file. If one is
 found, the filename of the file being created is compared with the filename
 patterns of the configuration file. The first pattern that matches is selected,
 and its KMS and PGP keys are used to encrypt the file.
+
+Creating a new file with the right keys is now as simple as
+
+.. code:: bash
+
+	$ sops <newfile>.prod.yaml
+
+Note that the configuration file is ignored when KMS or PGP parameters are
+passed on the sops command line or in environment variables.
 
 Important information on types
 ------------------------------

--- a/README.rst
+++ b/README.rst
@@ -280,6 +280,51 @@ KMS and PGP master keys defined in the file.
 
 	sops -r example.yaml
 
+Automating KMS/PGP configuration of new files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is often tedious to specify the `--kms` and `--pgp` parameters for creation
+of all new files. If your secrets are stored under a specific directory, like a
+`git` repository, you can create a `.sops.yaml` configuration file at the root
+directory to define which keys are used for which filename.
+
+Let's take an example:
+* file named **something.dev.yaml** should use one set of KMS A
+* file named **something.prod.yaml** should use another set of KMS B
+* all other files use a third set of KMS C
+* All live under **mysecretrepo/somethind.{dev,prod}.yaml**
+
+Under those circumstances, a configuration file placed at
+**mysecretrepo/.sops.yaml** can drive the two sets of KMS used for the two types
+of files.
+
+.. code:: yaml
+
+	# creation rules are evaluated sequentially, the first match wins
+	creation_rules:
+		# upon creation of a file that matches the pattern *.dev.yaml,
+		# KMS set A is used
+		- filename_pattern: \.dev\.yaml$
+		  kms: 'arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500,arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e+arn:aws:iam::361527076523:role/hiera-sops-prod'
+		  pgp: '1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A'
+
+		# prod files use KMS set B in the PROD IAM
+		- filename_pattern: \.prod\.yaml$
+		  kms: 'arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e+arn:aws:iam::361527076523:role/hiera-sops-prod,arn:aws:kms:eu-central-1:361527076523:key/cb1fab90-8d17-42a1-a9d8-334968904f94+arn:aws:iam::361527076523:role/hiera-sops-prod'
+		  pgp: '1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A'
+
+		# Finally, if the rules above have not matched, this one is a 
+		# catchall that will encrypt the file using KMS set C
+		- filename_pattern: .+
+		  kms: 'arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500,arn:aws:kms:us-west-2:142069644989:key/846cfb17-373d-49b9-8baf-f36b04512e47,arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e'
+		  pgp: '1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A'
+
+When creating any file under **mysecretrepo**, whether at the root or under
+a subdirectory, sops will recursively look for a `.sops.yaml` file. If one is
+found, the filename of the file being created is compared with the filename
+patterns of the configuration file. The first pattern that matches is selected,
+and its KMS and PGP keys are used to encrypt the file.
+
 Important information on types
 ------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name="sops",
     py_modules=['sops'],
-    version="1.9",
+    version="1.10",
     author="Julien Vehent",
     author_email="jvehent@mozilla.com",
     description="Secrets OPerationS (sops) is an editor of encrypted files",

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -473,10 +473,16 @@ def find_config_for_file(filename, configloc):
             # when we find a file, exit the loop
             configloc = (i * "../") + DEFAULT_CONFIG_FILE
             break
+    if not configloc:
+        # no configuration was found
+        return None
     # load the config file as yaml and look for creation rules that
     # contain a regex that matches the current filename
-    with open(configloc, "rb") as filedesc:
-        config = ruamel.yaml.load(filedesc, ruamel.yaml.RoundTripLoader)
+    try:
+        with open(configloc, "rb") as filedesc:
+            config = ruamel.yaml.load(filedesc, ruamel.yaml.RoundTripLoader)
+    except IOError:
+        panic("no configuration file found at '%s'" % configloc, 61)
     if 'creation_rules' not in config:
         return None
     for rule in config["creation_rules"]:
@@ -526,9 +532,9 @@ def verify_or_create_sops_branch(tree, kms_arns=None, pgp_fps=None):
     # we need a new data key
     has_at_least_one_method = False
     need_new_data_key = True
-    if kms_arns != "":
+    if kms_arns:
         tree, has_at_least_one_method = parse_kms_arn(tree, kms_arns)
-    if pgp_fps != "":
+    if pgp_fps:
         tree, has_at_least_one_method = parse_pgp_fp(tree, pgp_fps)
     if not has_at_least_one_method:
         panic("Error: No KMS ARN or PGP Fingerprint found to encrypt the data "

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -401,11 +401,13 @@ def initialize_tree(path, itype, kms_arns=None, pgp_fps=None, configloc=None):
             tree = json.loads(DEFAULT_JSON, object_pairs_hook=OrderedDict)
         else:
             tree['data'] = DEFAULT_TEXT
-        # look for a config file
-        config = find_config_for_file(path, configloc)
-        if config:
-            kms_arns = config.get("kms", None)
-            pgp_fps = config.get("pgp", None)
+        if not kms_arns and not pgp_fps:
+            # if no kms or pgp was provided on the command line or environment
+            # variables, look for a config file to get the values from
+            config = find_config_for_file(path, configloc)
+            if config:
+                kms_arns = config.get("kms", None)
+                pgp_fps = config.get("pgp", None)
         tree, need_key = verify_or_create_sops_branch(tree, kms_arns, pgp_fps)
     return tree, need_key, existing_file
 

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -38,7 +38,7 @@ else:
 if sys.version_info[0] == 3:
     raw_input = input
 
-VERSION = 1.9
+VERSION = 1.10
 
 DESC = """
 `sops` supports AWS KMS and PGP encryption:


### PR DESCRIPTION
This PR adds two things.
First, it ensures that, when creating new files, all master keys requested are available to encrypt the file's data key. `sops` would previously ignore the keys that are requested but not accessible, which is not a deterministic behavior to the user.

Second, it implements a configuration file to be added to sops' managed directory. Similar to `.git`, `sops` will look for a file called `.sops.yaml` backward in the directory tree and use its rules to select master keys to use when creating new files. This is, for now, only used on creation of new files, so we don't pay the cost of recursively looking for the config file for any other call to sops.

@mostlygeek: we discussed this together, maybe you want to comment?

r? @relud 