### PR TITLE
Support AWS KMS Encryption Context

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,6 +270,42 @@ appending it to the ARN of the master key, separated by a **+** sign::
 	<KMS ARN>+<ROLE ARN>
 	arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500+arn:aws:iam::927034868273:role/sops-dev-xyz
 
+AWS KMS Encryption Context
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SOPS has the ability to use AWS KMS key policy and encryption context
+<http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html>
+to further fine control access under the same master key.
+Encryption context is a set of key-value pairs. It is not part of ciphertext
+return but is cryptographically bound to the ciphertext. Decryption requires
+exact the same encryption context as the one you passed during encryption.
+You can use KMS key policy (as shown as below) or key grant to control who
+can perform decryption with certain encryption context.
+
+.. code:: json
+
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::111122223333:role/RoleForExampleApp"
+      },
+      "Action": "kms:Decrypt",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:EncryptionContext:AppName": "ExampleApp",
+          "kms:EncryptionContext:FilePath": "/var/opt/secrets/"
+        }
+      }
+    }
+
+You can specify encryption context in the `--encryption-context` flag by
+comma separated list of key-value pairs:
+
+	<EncryptionContext Key>:<EncryptionContext Value>,<EncryptionContext Key>:<EncryptionContext Value>
+	Environment:production,Role:web-server
+
+
 Key Rotation
 ~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -275,12 +275,9 @@ AWS KMS Encryption Context
 
 SOPS has the ability to use AWS KMS key policy and encryption context
 <http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html>
-to further fine control access under the same master key.
-Encryption context is a set of key-value pairs. It is not part of ciphertext
-return but is cryptographically bound to the ciphertext. Decryption requires
-exact the same encryption context as the one you passed during encryption.
-You can use KMS key policy (as shown as below) or key grant to control who
-can perform decryption with certain encryption context.
+to refine the access control of a given KMS master key.
+Encryption contexts can be used in conjunction with KMS Key Policies to define
+roles that can only access a given context. An example policy is shown below:
 
 .. code:: json
 
@@ -299,11 +296,13 @@ can perform decryption with certain encryption context.
       }
     }
 
-You can specify encryption context in the `--encryption-context` flag by
-comma separated list of key-value pairs:
+When creating a new file, you can specify encryption context in the
+`--encryption-context` flag by comma separated list of key-value pairs:
 
 	<EncryptionContext Key>:<EncryptionContext Value>,<EncryptionContext Key>:<EncryptionContext Value>
-	Environment:production,Role:web-server
+	eg.Environment:production,Role:web-server
+
+The encryption context will be stored in the file metadata and not need to be provided at decryption.
 
 
 Key Rotation

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -1068,8 +1068,10 @@ def get_key_from_kms(tree):
             errors.append("no kms client could be obtained for entry %s" %
                           entry['arn'])
             continue
+        context = entry['context'] if 'context' in entry else {}
         try:
-            kms_response = kms.decrypt(CiphertextBlob=b64decode(enc))
+            kms_response = kms.decrypt(CiphertextBlob=b64decode(enc),
+                                       EncryptionContext=context)
         except Exception as e:
             errors.append("kms %s failed with error: %s " % (entry['arn'], e))
             continue
@@ -1090,8 +1092,10 @@ def encrypt_key_with_kms(key, entry):
         print("ERROR: failed to initialize AWS KMS client for entry: %s" % err,
               file=sys.stderr)
         return None
+    context = entry['context'] if 'context' in entry else {}
     try:
-        kms_response = kms.encrypt(KeyId=entry['arn'], Plaintext=key)
+        kms_response = kms.encrypt(KeyId=entry['arn'], Plaintext=key,
+                                   EncryptionContext=context)
     except Exception as e:
         print("ERROR: failed to encrypt key using kms arn %s: %s" %
               (entry['arn'], e), file=sys.stderr)

--- a/tests/test_sops.py
+++ b/tests/test_sops.py
@@ -83,15 +83,21 @@ class TreeTest(unittest2.TestCase):
                 "656532927350:key/9006a8aa-0fa6-4c14-930e-a2dfb916de1d"
         pgp_fps = "85D77543B3D624B63CEA9E6DBC17301B491B3F21," + \
                 "C9CAB0AF1165060DB58D6D6B2653B624D620786D"
+        kms_context = "Environment:production,Role:web-server"
         tree = OrderedDict()
         tree, ign = sops.verify_or_create_sops_branch(tree,
                                                       kms_arns=kms_arns,
-                                                      pgp_fps=pgp_fps)
+                                                      pgp_fps=pgp_fps,
+                                                      kms_context=kms_context)
         log.debug("%s", tree)
         assert len(tree['sops']['kms']) == 2
         assert tree['sops']['kms'][0]['arn'] == "arn:aws:kms:us-east-1:656532927350:key/920aff2e-c5f1-4040-943a-047fa387b27e"
         assert tree['sops']['kms'][0]['role'] == "arn:aws:iam::927034868273:role/sops-dev"
+        assert tree['sops']['kms'][0]['context']['Environment'] == "production"
+        assert tree['sops']['kms'][0]['context']['Role'] == "web-server"
         assert tree['sops']['kms'][1]['arn'] == "arn:aws:kms:ap-southeast-1:656532927350:key/9006a8aa-0fa6-4c14-930e-a2dfb916de1d"
+        assert tree['sops']['kms'][1]['context']['Environment'] == "production"
+        assert tree['sops']['kms'][1]['context']['Role'] == "web-server"
         assert len(tree['sops']['pgp']) == 2
         assert tree['sops']['pgp'][0]['fp'] == "85D77543B3D624B63CEA9E6DBC17301B491B3F21"
         assert tree['sops']['pgp'][1]['fp'] == "C9CAB0AF1165060DB58D6D6B2653B624D620786D"


### PR DESCRIPTION
- user can specify "Encryption Context" to each data key encrypted by KMS
- the Encryption Context can be used to restrict access with KMS Policy

some reference on encryption context added:
http://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html
http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html