### PR TITLE
Added warning message when PGP/KMS items have invalid format

### DIFF
--- a/json/store.go
+++ b/json/store.go
@@ -247,7 +247,11 @@ func (store Store) kmsEntries(in []interface{}) (sops.KeySource, error) {
 	var keys []sops.MasterKey
 	keysource := sops.KeySource{Name: "kms", Keys: keys}
 	for _, v := range in {
-		entry := v.(map[string]interface{})
+		entry, ok := v.(map[string]interface{})
+		if !ok {
+			fmt.Println("KMS entry has invalid format, skipping...")
+			continue
+		}
 		key := &kms.MasterKey{}
 		key.Arn = entry["arn"].(string)
 		key.EncryptedKey = entry["enc"].(string)
@@ -269,7 +273,11 @@ func (store Store) pgpEntries(in []interface{}) (sops.KeySource, error) {
 	var keys []sops.MasterKey
 	keysource := sops.KeySource{Name: "pgp", Keys: keys}
 	for _, v := range in {
-		entry := v.(map[string]interface{})
+		entry, ok := v.(map[string]interface{})
+		if !ok {
+			fmt.Println("PGP entry has invalid format, skipping...")
+			continue
+		}
 		key := &pgp.MasterKey{}
 		key.Fingerprint = entry["fp"].(string)
 		key.EncryptedKey = entry["enc"].(string)

--- a/yaml/store.go
+++ b/yaml/store.go
@@ -164,7 +164,11 @@ func (store *Store) kmsEntries(in []interface{}) (sops.KeySource, error) {
 	var keys []sops.MasterKey
 	keysource := sops.KeySource{Name: "kms", Keys: keys}
 	for _, v := range in {
-		entry := v.(map[interface{}]interface{})
+		entry, ok := v.(map[interface{}]interface{})
+		if !ok {
+			fmt.Println("KMS entry has invalid format, skipping...")
+			continue
+		}
 		key := &kms.MasterKey{}
 		key.Arn = entry["arn"].(string)
 		key.EncryptedKey = entry["enc"].(string)
@@ -186,7 +190,11 @@ func (store *Store) pgpEntries(in []interface{}) (sops.KeySource, error) {
 	var keys []sops.MasterKey
 	keysource := sops.KeySource{Name: "pgp", Keys: keys}
 	for _, v := range in {
-		entry := v.(map[interface{}]interface{})
+		entry, ok := v.(map[interface{}]interface{})
+		if !ok {
+			fmt.Println("PGP entry has invalid format, skipping...")
+			continue
+		}
 		key := &pgp.MasterKey{}
 		key.Fingerprint = entry["fp"].(string)
 		key.EncryptedKey = entry["enc"].(string)


### PR DESCRIPTION
In files coming from old versions of sops, sometimes the PGP or KMS branch in the sops branch of the document (also known as the metadata section) contains invalid master keys, such as null items. For example:

```
sops:
    kms:
    -
```

Now a warning will be shown and that entry will be skipped, instead of panicking.