### PR TITLE
When converting master key to map, store context keys alphabetically sorted

### DIFF
--- a/cmd/sops/version.go
+++ b/cmd/sops/version.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-const version = "2.0.1"
+const version = "2.0.2"
 
 func printVersion(c *cli.Context) {
 	out := fmt.Sprintf("%s %s", c.App.Name, c.App.Version)

--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -169,6 +170,7 @@ func (key MasterKey) ToMap() map[string]string {
 		for k, v := range key.EncryptionContext {
 			outContexts = append(outContexts, k+":"+*v)
 		}
+		sort.Strings(outContexts)
 		out["context"] = strings.Join(outContexts, ",")
 	}
 	return out

--- a/kms/keysource_test.go
+++ b/kms/keysource_test.go
@@ -87,6 +87,7 @@ func TestParseEncryptionContext(t *testing.T) {
 func TestKeyToMap(t *testing.T) {
 	value1 := "value1"
 	value2 := "value2"
+	value3 := "value3"
 	key := MasterKey{
 		CreationDate: time.Date(2016, time.October, 31, 10, 0, 0, 0, time.UTC),
 		Arn:          "foo",
@@ -95,6 +96,7 @@ func TestKeyToMap(t *testing.T) {
 		EncryptionContext: map[string]*string{
 			"key1": &value1,
 			"key2": &value2,
+			"AAA_this_key_should_be_first": &value3,
 		},
 	}
 	assert.Equal(t, map[string]string{
@@ -102,6 +104,6 @@ func TestKeyToMap(t *testing.T) {
 		"role":       "bar",
 		"enc":        "this is encrypted",
 		"created_at": "2016-10-31T10:00:00Z",
-		"context":    "key1:value1,key2:value2",
+		"context":    "AAA_this_key_should_be_first:value3,key1:value1,key2:value2",
 	}, key.ToMap())
 }


### PR DESCRIPTION
This fixes issue #163, and make toMap() more stable across different runs.