### PR TITLE
Better error message when unable to retrieve data key

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -354,6 +354,9 @@ func decryptTree(tree sops.Tree, ignoreMac bool) (sops.Tree, map[string][]interf
 
 func decrypt(c *cli.Context, tree sops.Tree, outputStore sops.Store) ([]byte, error) {
 	tree, _, err := decryptTree(tree, c.Bool("ignore-mac"))
+	if err != nil {
+		return nil, err
+	}
 	if c.String("extract") != "" {
 		v, err := tree.Branch.Truncate(c.String("extract"))
 		if err != nil {


### PR DESCRIPTION
Now an error message like this one is shown:

```
Could not decrypt the data key with any of the master keys:
	[GPG]: 1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A:	Reading PGP message failed: openpgp: incorrect key
	[GPG]: 85D77543B3D624B63CEA9E6DBC17301B491B3F21:	Reading PGP message failed: openpgp: incorrect key```