### PR TITLE
cmd/main: fix shlex branch of editor parsing

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -301,7 +301,8 @@ func runEditor(path string) error {
 		if err != nil {
 			return fmt.Errorf("Invalid $EDITOR: %s", editor)
 		}
-		cmd = exec.Command(parts[0], parts...)
+		parts = append(parts, path)
+		cmd = exec.Command(parts[0], parts[1:]...)
 	}
 
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
#211 introduced a regression, which causes the editor to be executed like "$EDITOR $EDITOR".