### PR TITLE
[PYTHON] Unpin cryptography requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         'ruamel.yaml==0.11.7',
         'boto3>=1.1.3',
-        'cryptography==1.4',
+        'cryptography>=1.4',
         'setuptools>=18.8.1',
         'ordereddict>=1.1',
         'simplejson>=3.8'],


### PR DESCRIPTION
Doesn't seem like there's a reason not to use newer versions of cryptography and it has the advantage of being much easier to install with wheels.