### PR TITLE
Fix IV size and constant-time MAC comparison

### DIFF
--- a/aes/decryptor.go
+++ b/aes/decryptor.go
@@ -18,7 +18,8 @@ type encryptedValue struct {
 	datatype string
 }
 
-const nonceSize int = 32
+// AES-GCM standard nonce size is 96-bits (12 bytes)
+const nonceSize int = 12
 
 type stashData struct {
 	iv        []byte

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -3,6 +3,7 @@ package decrypt // import "go.mozilla.org/sops/decrypt"
 import (
 	"crypto/subtle"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -12,6 +13,9 @@ import (
 	sopsjson "go.mozilla.org/sops/json"
 	sopsyaml "go.mozilla.org/sops/yaml"
 )
+
+// Constant indicating a MAC tag mismatch.
+var errMacMismatch error = errors.New("Failed to verify data integrity.")
 
 // File is a wrapper around Data that reads a local encrypted
 // file and returns its cleartext data in an []byte
@@ -85,7 +89,7 @@ func Data(data []byte, format string) (cleartext []byte, err error) {
 
 	// Use a constant-time MAC tag comparison to avoid timing attacks: https://codahale.com/a-lesson-in-timing-attacks/
 	if subtle.ConstantTimeCompare(computedMacBytes, originalMacBytes) != 1 {
-		return nil, fmt.Errorf("Failed to verify data integrity. expected mac %q, got %q", originalMac, mac)
+		return nil, errMacMismatch
 	}
 
 	return store.Marshal(tree.Branch)

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -1,6 +1,8 @@
 package decrypt // import "go.mozilla.org/sops/decrypt"
 
 import (
+	"crypto/subtle"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -71,7 +73,18 @@ func Data(data []byte, format string) (cleartext []byte, err error) {
 		key,
 		metadata.LastModified.Format(time.RFC3339),
 	)
-	if originalMac != mac {
+
+	computedMacBytes, err := hex.DecodeString(mac)
+	if err != nil {
+		return nil, err
+	}
+	originalMacBytes, err := hex.DecodeString(originalMac.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	// Use a constant-time MAC tag comparison to avoid timing attacks: https://codahale.com/a-lesson-in-timing-attacks/
+	if subtle.ConstantTimeCompare(computedMacBytes, originalMacBytes) != 1 {
 		return nil, fmt.Errorf("Failed to verify data integrity. expected mac %q, got %q", originalMac, mac)
 	}
 


### PR DESCRIPTION
This fixes #220 and fixes #222 by changing the IV size to 96-bits (12 bytes) and using crypto/subtle/ConstantTimeCompare to compare the computed and stored SHA-512 hashes.

NB: The PGP tests are failing for me (before and after these fixes) as go's openpgp seems unable to find the secret key it just imported into the secring. I have no idea why not, as every other pgp software on my machine finds it just fine. I have run the rest of the test suite with no errors.