### PR TITLE
Revert "Fix IV size and constant-time MAC comparison"

### DIFF
--- a/aes/decryptor.go
+++ b/aes/decryptor.go
@@ -18,8 +18,7 @@ type encryptedValue struct {
 	datatype string
 }
 
-// AES-GCM standard nonce size is 96-bits (12 bytes)
-const nonceSize int = 12
+const nonceSize int = 32
 
 type stashData struct {
 	iv        []byte

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -1,9 +1,6 @@
 package decrypt // import "go.mozilla.org/sops/decrypt"
 
 import (
-	"crypto/subtle"
-	"encoding/hex"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -13,9 +10,6 @@ import (
 	sopsjson "go.mozilla.org/sops/json"
 	sopsyaml "go.mozilla.org/sops/yaml"
 )
-
-// Constant indicating a MAC tag mismatch.
-var errMacMismatch error = errors.New("Failed to verify data integrity.")
 
 // File is a wrapper around Data that reads a local encrypted
 // file and returns its cleartext data in an []byte
@@ -77,19 +71,8 @@ func Data(data []byte, format string) (cleartext []byte, err error) {
 		key,
 		metadata.LastModified.Format(time.RFC3339),
 	)
-
-	computedMacBytes, err := hex.DecodeString(mac)
-	if err != nil {
-		return nil, err
-	}
-	originalMacBytes, err := hex.DecodeString(originalMac.(string))
-	if err != nil {
-		return nil, err
-	}
-
-	// Use a constant-time MAC tag comparison to avoid timing attacks: https://codahale.com/a-lesson-in-timing-attacks/
-	if subtle.ConstantTimeCompare(computedMacBytes, originalMacBytes) != 1 {
-		return nil, errMacMismatch
+	if originalMac != mac {
+		return nil, fmt.Errorf("Failed to verify data integrity. expected mac %q, got %q", originalMac, mac)
 	}
 
 	return store.Marshal(tree.Branch)


### PR DESCRIPTION
Reverts mozilla/sops#225

This introduced a regression preventing editing of files created with earlier versions of sops. To reproduce:

```
old_sops foo.yaml
# Edit the file and exit the editor
new_sops foo.yaml
# Edit the file and exit the editor
```

And `new_sops` panics:

```
panic: cipher: incorrect nonce length given to GCM

goroutine 1 [running]:
crypto/aes.(*gcmAsm).Seal(0xc42029cd80, 0x0, 0x0, 0x0, 0xc420228180, 0x20, 0x21, 0xc420229650, 0x2e, 0x30, ...)
	/usr/local/Cellar/go/1.8.1/libexec/src/crypto/aes/aes_gcm.go:100 +0x564
go.mozilla.org/sops/aes.Cipher.Encrypt(0x14cc580, 0xc42021e9c0, 0xc420297800, 0x20, 0x600, 0xc42021e9d0, 0x6, 0x15195c0, 0xc4202282a0, 0xc42008a840, ...)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/aes/decryptor.go:148 +0x670
go.mozilla.org/sops/aes.(*Cipher).Encrypt(0x183a410, 0x14cc580, 0xc42021e9c0, 0xc420297800, 0x20, 0x600, 0xc42021e9d0, 0x6, 0x15195c0, 0xc4202282a0, ...)
	<autogenerated>:2 +0xbe
go.mozilla.org/sops.Tree.Encrypt.func1(0x14cc580, 0xc42021e9c0, 0xc42021e9b0, 0x1, 0x1, 0xc42021e9b0, 0x0, 0xc4200f07a0, 0x181e880)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/sops.go:220 +0x4c4
go.mozilla.org/sops.TreeBranch.walkValue(0xc42018dd40, 0x2, 0x2, 0x14cc580, 0xc42021e3f0, 0xc42021e9b0, 0x1, 0x1, 0xc4200f0970, 0x1b00000, ...)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/sops.go:148 +0x848
go.mozilla.org/sops.TreeBranch.walkBranch(0xc42018dd40, 0x2, 0x2, 0xc42018dd40, 0x2, 0x2, 0x183a410, 0x0, 0x0, 0xc4200f0970, ...)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/sops.go:190 +0x164
go.mozilla.org/sops.Tree.Encrypt(0xc42018dd40, 0x2, 0x2, 0xed11c59af, 0x0, 0x0, 0xc4201576f0, 0xc, 0xc4201abe60, 0x117, ...)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/sops.go:230 +0x1c9
main.encryptTree(0xc42018dd40, 0x2, 0x2, 0xed11c59af, 0x0, 0x0, 0xc4201576f0, 0xc, 0xc4201abe60, 0x117, ...)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/cmd/sops/main.go:440 +0x284
main.edit(0xc4200d9040, 0x7fff5fbffaea, 0x8, 0xc420079800, 0x4b3, 0x6b3, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/cmd/sops/main.go:711 +0x62a
main.main.func1(0xc4200d9040, 0x0, 0x0)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/cmd/sops/main.go:264 +0xa63
go.mozilla.org/sops/vendor/gopkg.in/urfave/cli%2ev1.HandleAction(0x14da860, 0x15986d0, 0xc4200d9040, 0x0, 0x0)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/vendor/gopkg.in/urfave/cli.v1/app.go:485 +0xd4
go.mozilla.org/sops/vendor/gopkg.in/urfave/cli%2ev1.(*App).Run(0xc420122680, 0xc42000c220, 0x2, 0x2, 0x0, 0x0)
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/vendor/gopkg.in/urfave/cli.v1/app.go:259 +0x70d
main.main()
	/Users/autrilla/Projects/go/src/go.mozilla.org/sops/cmd/sops/main.go:286 +0xe4f
```

I'd want to keep `master` green because some users obtain sops with `go get`. Once this is fixed we can merge again.

cc @NeilMadden