### PR TITLE
change: check valid arn partition

### DIFF
--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -140,13 +140,12 @@ func (key MasterKey) createStsSession(config aws.Config, sess *session.Session) 
 }
 
 func (key MasterKey) createSession() (*session.Session, error) {
-	// possible partitions in $1: aws, aws-cn, aws-us-gov
-	re := regexp.MustCompile(`^arn:(aws[\w-]*):kms:(.+):([0-9]+):key/(.+)$`)
+	re := regexp.MustCompile(`^arn:aws[\w-]*:kms:(.+):[0-9]+:key/.+$`)
 	matches := re.FindStringSubmatch(key.Arn)
 	if matches == nil {
 		return nil, fmt.Errorf("No valid ARN found in %q", key.Arn)
 	}
-	config := aws.Config{Region: aws.String(matches[2])}
+	config := aws.Config{Region: aws.String(matches[1])}
 	opts := session.Options{
 		Config:                  config,
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,

--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -140,12 +140,13 @@ func (key MasterKey) createStsSession(config aws.Config, sess *session.Session) 
 }
 
 func (key MasterKey) createSession() (*session.Session, error) {
-	re := regexp.MustCompile(`^arn:aws:kms:(.+):([0-9]+):key/(.+)$`)
+	// possible partitions in $1: aws, aws-cn, aws-us-gov
+	re := regexp.MustCompile(`^arn:(aws[\w-]*):kms:(.+):([0-9]+):key/(.+)$`)
 	matches := re.FindStringSubmatch(key.Arn)
 	if matches == nil {
 		return nil, fmt.Errorf("No valid ARN found in %q", key.Arn)
 	}
-	config := aws.Config{Region: aws.String(matches[1])}
+	config := aws.Config{Region: aws.String(matches[2])}
 	opts := session.Options{
 		Config:                  config,
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,


### PR DESCRIPTION
[issue 214](https://github.com/mozilla/sops/issues/214)

Change to make `createSession` handle the current valid AWS partitions:

* `aws`
* `aws-cn`
* `aws-us-gov`

Previously only `aws` had been hard-coded in the arn check