### PR TITLE
Create slim dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - rpm
       - ruby
       - python3
+      - docker-ce
 
 before_install:
   - gem install fpm || sudo gem install fpm
@@ -34,3 +35,10 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+
+after_success:
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker build -t mozilla/sops:slim -f Dockerfile-slim .;
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker push mozilla/sops:slim;
+    fi

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,0 +1,10 @@
+FROM golang:1.9
+
+COPY . /go/src/go.mozilla.org/sops
+WORKDIR /go/src/go.mozilla.org/sops
+RUN mkdir /app/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/sops go.mozilla.org/sops/cmd/sops
+
+FROM scratch
+COPY --from=0 /app/sops /usr/bin/sops
+CMD ["sops"]


### PR DESCRIPTION
Useful as a simple way to get a SOPS binary. Users can then mount whichever secrets they want into the container (and potentially a key service socket) and decrypt/encrypt from inside.