### PR TITLE
Use go.mozilla.org package name in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,20 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/mozilla/sops
+    working_directory: /go/src/go.mozilla.org/sops
     docker:
       - image: circleci/golang:1.8
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: Build Sops
-          command: make 
-      - setup_remote_docker                                                                                                                                                                                                                                    
-      - run:                                                                                                                                                                                                                                                   
-          name: Build containers                                                                                                                                                                                                                               
-          command: |                                                                                                                                                                                                                                           
-            docker build -t mozilla/sops .                                                                                                                                                                                                          
-            docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"                                                                                                                                                                          
+          command: make
+      - run:
+          name: Build containers
+          command: |
+            docker build -t mozilla/sops .
+            docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
       - run:
           name: Push containers
           command: |
@@ -22,4 +22,3 @@ jobs:
                 ./bin/ci/deploy_dockerhub.sh "latest"
                 ./bin/ci/deploy_dockerhub.sh "$CIRCLE_SHA1"
             fi
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,6 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Build Sops
-          command: make
-      - run:
           name: Build containers
           command: |
             docker build -t mozilla/sops .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM golang:1.7
+FROM golang:1.8
 
 COPY . /go/src/go.mozilla.org/sops
 WORKDIR /go/src/go.mozilla.org/sops
-RUN go get -d -v
-RUN go test ./...
-RUN go install -v ./...
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /bin/sops ./cmd/sops
+RUN apt-get update
+RUN apt-get install -y vim python-pip emacs
+RUN pip install awscli
+ENV EDITOR vim


### PR DESCRIPTION
Also updates the Docker image to include the AWS cli and use a newer version of Go