### PR TITLE
Fix typo in help text for unencrypted-suffix

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -325,7 +325,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "unencrypted-suffix",
-			Usage: "override the unencrypted key suffix. default: unencrypted_",
+			Usage: "override the unencrypted key suffix.",
 			Value: sops.DefaultUnencryptedSuffix,
 		},
 		cli.StringFlag{


### PR DESCRIPTION
While working on a tool that uses `sops` under the hood, I noticed that the help text for `--unencrypted-suffix` contained two explanations of the default, one of which actually looked like a prefix. This PR removes the hard coded default string and leans on the one generated by the cli package. 

Old help message:
```
   --unencrypted-suffix value               override the unencrypted key suffix. default: unencrypted_ (default: "_unencrypted")
```

New help message:
```
   --unencrypted-suffix value               override the unencrypted key suffix. (default: "_unencrypted")
```