### PR TITLE
Don't dereference a null pointer if the config file is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,11 @@ func loadForFileFromBytes(confBytes []byte, filePath string, kmsEncryptionContex
 			break
 		}
 	}
+
+	if rule == nil {
+		return nil, fmt.Errorf("error loading config: no creation rules found")
+	}
+
 	var groups []sops.KeyGroup
 	if len(rule.KeyGroups) > 0 {
 		for _, group := range rule.KeyGroups {

--- a/config/config.go
+++ b/config/config.go
@@ -110,7 +110,7 @@ func loadForFileFromBytes(confBytes []byte, filePath string, kmsEncryptionContex
 	}
 
 	if rule == nil {
-		return nil, fmt.Errorf("error loading config: no creation rules found")
+		return nil, fmt.Errorf("error loading config: no matching creation rules found")
 	}
 
 	var groups []sops.KeyGroup

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -141,7 +141,7 @@ func TestLoadConfigFileWithGroups(t *testing.T) {
 
 func TestLoadInvalidConfigFile(t *testing.T) {
 	_, err := loadForFileFromBytes(sampleInvalidConfig, "foobar2000", nil)
-	assert.Equal(t, err.Error(), "error loading config: no creation rules found")
+	assert.NotNil(t, err)
 }
 
 func TestKeyGroupsForFile(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -76,6 +76,10 @@ creation_rules:
       - resource_id: baz
 `)
 
+var sampleInvalidConfig = []byte(`
+creation_rules:
+`)
+
 func TestLoadConfigFile(t *testing.T) {
 	expected := configFile{
 		CreationRules: []creationRule{
@@ -133,6 +137,11 @@ func TestLoadConfigFileWithGroups(t *testing.T) {
 	err := conf.load(sampleConfigWithGroups)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, expected, conf)
+}
+
+func TestLoadInvalidConfigFile(t *testing.T) {
+	_, err := loadForFileFromBytes(sampleInvalidConfig, "foobar2000", nil)
+	assert.Equal(t, err.Error(), "error loading config: no creation rules found")
 }
 
 func TestKeyGroupsForFile(t *testing.T) {


### PR DESCRIPTION
While working on a tool that uses `sops` under the hood, I accidentally cleared out my `.sops.yaml` file. When I ran `sops` it caused a panic that I traced back to an unchecked nil pointer in the function that loads config files. Here's some sample output: 
```yaml
# example.yaml
creation_rules:
```

```
❯ sops -e example.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x15a554a]

goroutine 1 [running]:
go.mozilla.org/sops/config.loadForFileFromBytes(0xc4201d0000, 0x46, 0x246, 0x7fff5fbff488, 0xc, 0x0, 0x0, 0x1726084, 0x1)
        /private/tmp/sops-20171011-79678-1wrcwgy/sops-3.0.0/src/go.mozilla.org/sops/config/config.go:112 +0x19a
go.mozilla.org/sops/config.LoadForFile(0xc420019190, 0xa, 0x7fff5fbff488, 0xc, 0x0, 0x0, 0xc420164960, 0x100d6fe)
        /private/tmp/sops-20171011-79678-1wrcwgy/sops-3.0.0/src/go.mozilla.org/sops/config/config.go:153 +0x125
main.keyGroups(0xc4200bcb00, 0x7fff5fbff488, 0xc, 0x1, 0x1b25018, 0x0, 0x1f08260, 0x1053d90)
        /private/tmp/sops-20171011-79678-1wrcwgy/sops-3.0.0/src/go.mozilla.org/sops/cmd/sops/main.go:648 +0x7ad
main.main.func5(0xc4200bcb00, 0x0, 0x0)
        /private/tmp/sops-20171011-79678-1wrcwgy/sops-3.0.0/src/go.mozilla.org/sops/cmd/sops/main.go:371 +0x23a4
go.mozilla.org/sops/vendor/gopkg.in/urfave/cli%2ev1.HandleAction(0x1639ec0, 0x1752d20, 0xc4200bcb00, 0x0, 0x0)
        /private/tmp/sops-20171011-79678-1wrcwgy/sops-3.0.0/src/go.mozilla.org/sops/vendor/gopkg.in/urfave/cli.v1/app.go:490 +0xd2
go.mozilla.org/sops/vendor/gopkg.in/urfave/cli%2ev1.(*App).Run(0xc4201851e0, 0xc4200100c0, 0x3, 0x3, 0x0, 0x0)
        /private/tmp/sops-20171011-79678-1wrcwgy/sops-3.0.0/src/go.mozilla.org/sops/vendor/gopkg.in/urfave/cli.v1/app.go:264 +0x635
main.main()
        /private/tmp/sops-20171011-79678-1wrcwgy/sops-3.0.0/src/go.mozilla.org/sops/cmd/sops/main.go:519 +0x201b
```

This PR adds a check after the creation rules are parsed to see if we actually found at least one, and errors if we don't. 