### PR TITLE
add IsBinary: true to FileHints when encoding with crypto/openpgp

### DIFF
--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -127,7 +127,7 @@ func (key *MasterKey) encryptWithCryptoOpenPGP(dataKey []byte) error {
 	if err != nil {
 		return err
 	}
-	plaintextbuf, err := openpgp.Encrypt(armorbuf, []*openpgp.Entity{&entity}, nil, nil, nil)
+	plaintextbuf, err := openpgp.Encrypt(armorbuf, []*openpgp.Entity{&entity}, nil, &openpgp.FileHints{IsBinary: true}, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
since we encode binary data this is generally a good idea

this commit fixes #278 - now both crypto/openpgp and gpg work in a binary
mode, and we can safely use both interchangeably
(e.g. encrypt with crypto/openpgp, and then decrypt with gpg)