### PR TITLE
Add parameter to optionally validate all keys on decrypt

### DIFF
--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -26,11 +26,13 @@ type DecryptTreeOpts struct {
 	IgnoreMac bool
 	// Cipher is the cryptographic cipher to use to decrypt the values inside the tree
 	Cipher sops.Cipher
+	// ValidateAllKMSKeys will ensure that the object can be decrypted by all keys, rather than by any
+	ValidateAllKMSKeys bool
 }
 
 // DecryptTree decrypts the tree passed in through the DecryptTreeOpts and additionally returns the decrypted data key
 func DecryptTree(opts DecryptTreeOpts) (dataKey []byte, err error) {
-	dataKey, err = opts.Tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err = opts.Tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, opts.ValidateAllKMSKeys)
 	if err != nil {
 		return nil, NewExitError(err, codes.CouldNotRetrieveKey)
 	}

--- a/cmd/sops/decrypt.go
+++ b/cmd/sops/decrypt.go
@@ -10,13 +10,14 @@ import (
 )
 
 type decryptOpts struct {
-	Cipher      sops.Cipher
-	InputStore  sops.Store
-	OutputStore sops.Store
-	InputPath   string
-	IgnoreMAC   bool
-	Extract     []interface{}
-	KeyServices []keyservice.KeyServiceClient
+	Cipher             sops.Cipher
+	InputStore         sops.Store
+	OutputStore        sops.Store
+	InputPath          string
+	IgnoreMAC          bool
+	Extract            []interface{}
+	KeyServices        []keyservice.KeyServiceClient
+	ValidateAllKMSKeys bool
 }
 
 func decrypt(opts decryptOpts) (decryptedFile []byte, err error) {
@@ -26,10 +27,11 @@ func decrypt(opts decryptOpts) (decryptedFile []byte, err error) {
 	}
 
 	_, err = common.DecryptTree(common.DecryptTreeOpts{
-		Cipher:      opts.Cipher,
-		IgnoreMac:   opts.IgnoreMAC,
-		Tree:        tree,
-		KeyServices: opts.KeyServices,
+		Cipher:             opts.Cipher,
+		IgnoreMac:          opts.IgnoreMAC,
+		Tree:               tree,
+		KeyServices:        opts.KeyServices,
+		ValidateAllKMSKeys: opts.ValidateAllKMSKeys,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -344,6 +344,10 @@ func main() {
 			Name:  "shamir-secret-sharing-threshold",
 			Usage: "the number of master keys required to retrieve the data key with shamir",
 		},
+		cli.BoolFlag{
+			Name:  "validate-all-kms-keys",
+			Usage: "when decrypting ensure all KMS keys are valid",
+		},
 	}, keyserviceFlags...)
 
 	app.Action = func(c *cli.Context) error {
@@ -396,13 +400,14 @@ func main() {
 				return common.NewExitError(fmt.Errorf("error parsing --extract path: %s", err), codes.InvalidTreePathFormat)
 			}
 			output, err = decrypt(decryptOpts{
-				OutputStore: outputStore,
-				InputStore:  inputStore,
-				InputPath:   fileName,
-				Cipher:      aes.NewCipher(),
-				Extract:     extract,
-				KeyServices: svcs,
-				IgnoreMAC:   c.Bool("ignore-mac"),
+				OutputStore:        outputStore,
+				InputStore:         inputStore,
+				InputPath:          fileName,
+				Cipher:             aes.NewCipher(),
+				Extract:            extract,
+				KeyServices:        svcs,
+				IgnoreMAC:          c.Bool("ignore-mac"),
+				ValidateAllKMSKeys: c.Bool("validate-all-kms-keys"),
 			})
 		}
 		if c.Bool("rotate") {

--- a/cmd/sops/subcommand/groups/add.go
+++ b/cmd/sops/subcommand/groups/add.go
@@ -25,7 +25,7 @@ func Add(opts AddOpts) error {
 	if err != nil {
 		return err
 	}
-	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/sops/subcommand/groups/delete.go
+++ b/cmd/sops/subcommand/groups/delete.go
@@ -27,7 +27,7 @@ func Delete(opts DeleteOpts) error {
 	if err != nil {
 		return err
 	}
-	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -86,7 +86,7 @@ func updateFile(opts Opts) error {
 			return nil
 		}
 	}
-	key, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	key, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, false)
 	if err != nil {
 		return fmt.Errorf("error getting data key: %s", err)
 	}


### PR DESCRIPTION
In certain circumstances you may wish to validate that all KMS keys
are able to correctly decrypt a secret.
This enables the passing of a boolean parameter which does this.