### PR TITLE
Don't consider io.EOF returned by Decoder.Token as error

### DIFF
--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -84,7 +84,7 @@ var errEndOfObject = fmt.Errorf("End of object")
 func (store Store) treeItemFromJSONDecoder(dec *json.Decoder) (sops.TreeItem, error) {
 	var item sops.TreeItem
 	key, err := dec.Token()
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return item, err
 	}
 	if k, ok := key.(string); ok {

--- a/stores/json/store_test.go
+++ b/stores/json/store_test.go
@@ -126,6 +126,12 @@ func TestDecodeSimpleJSONObject(t *testing.T) {
 	assert.Equal(t, expected, branch)
 }
 
+func TestDecodeNumber(t *testing.T) {
+	in := `42`
+	_, err := Store{}.treeBranchFromJSON([]byte(in))
+	assert.NotNil(t, err)
+}
+
 func TestDecodeNestedJSONObject(t *testing.T) {
 	in := `{"foo": {"foo": "bar"}}`
 	expected := sops.TreeBranch{


### PR DESCRIPTION
[`Decoder.Token`](https://golang.org/pkg/encoding/json/#Decoder.Token) returns nil, io.EOF at the input stream.

This caused the output json to have no "data" key for an input containing a number:

```
{
        "sops": {
                "kms": null,
                "gcp_kms": null,
                "lastmodified": "2018-01-14T14:51:51Z",
                "mac": "ENC[AES256_GCM,data:miI91EH0VGqTY9DuJweV61++dq1LmdBwbU/tkaznCeVo2H7z0vws0FdDJiKUiyCwd+PYkpklinVyGWzxDjgR1yWch+9uU4zFkwSiNwLTdQRitYE9Kwxd37E7+AFmJtZIfIdUZsx/gFP4YZ4Pn2cgVK6n9sNRyaGhR4PyCp7TXT4=,iv:XnyghTNLba1edrVYk8sum38pe736T3L5yGJMmBocDyE=,tag:b3z730u8+hPiNxmg8REFHg==,type:str]",
                "pgp": [
                        {
                                "created_at": "2018-01-14T14:51:51Z",
                                "enc": "-----BEGIN PGP MESSAGE-----\n\nwcFMA90gOM45xlRNARAAj8AtDWZakRBpMmqRH3z6F+hIkyt2xpP911MAHpU1e4ma\nNZfUcKJybg2XFbAj40uDSEE1o1+hebU18nzYVwVUiDKBGN5f3rSgAIgtcK8u9JT2\nhRPndP7wkFK1t1+n3ne40ZotdqYefCLjHUalmS8Ka5wYDXGD9fOR3zBoaJ1VFWYu\nZyOltpqK76AFZ8dJkBBXcZCKfmZ2h2C9/tfSq5Hjibzddd/zit09zXsyHE6McFJU\n3YPGmGQ/kE+/1vkELIF3suGy7yB3Um0cRCEVnHoZJkE+lRZtxKKJ91oKLOfwJkoT\nOAHmeRJxDE45eae/wbWS4KHUFJ2IvfnUuaNCVrnYyzRP05wFxAuZI7XcV3ckVfaM\nBW2GkAUESfY9zYkTm/lOpUhAjEpqzjG+lSCt9VdHMMqOl8N4z6U5qzznm1ZL4Wf9\nbEV0zRc5XECmM6yjx7KHA8ivjdgxpKY9HgBI5ZkfjgoORfOaZaiVdteRmEOQM3yS\nWN+QTt4dkcfsqdpmYyHbCatgV9rsZdcIHS1kZ4EK7HMKzwR9+caRFA+o3NOm0hyx\nbNnMldVFr771KFoneau13A5HdZGdZRO7qMfpVZjdDQ8dFR1xtAimeoSGqIv5rcT3\n8UzrnNuSkHlPZHNgBloV5DoFLtWzd9VZCOl1KyLQLsSqQgbi1mbZlAQWfdWbwqHS\n4AHk3ef1I8MjQxVJFD4jSgC80OHzIeBK4C/heu/gfuKjuYWI4MLlPiuN6e+yoFT+\nR75GX1GgqTWP52gwxstEibTQ7n9zl6/gUeQ1/T+QOFDfajpawb8+xxyx4kjOzPnh\nU4MA\n=VSfw\n-----END PGP MESSAGE-----",
                                "fp": "C8F69F5F7059C32B3328DFE48BE9D15D0B0D06EB"
                        }
                ],
                "unencrypted_suffix": "_unencrypted",
                "version": "3.0.0"
        }
}
```

After the change:

```
{
        "data": "ENC[AES256_GCM,data:PVw=,iv:cCDbWu1jdYkCIUcF/BtZGBs6mSWtdTI5ZF/A/i7RxIY=,tag:sFtal0nSo2koPDxnaKxLgA==,type:str]",
        "sops": {
                "kms": null,
                "gcp_kms": null,
                "lastmodified": "2018-01-14T14:52:38Z",
                "mac": "ENC[AES256_GCM,data:BOyvRlaMKIGRcNOnmBGnN/Qz7i/l6Lhl5lx1OJ1VMb6nhuKkhCySktGVYOElUTgLc3CDKLfELNKiID2i6HKAkSAWQyYC1tIPAQTcBtnVd2Pt7Adzz8i8JFzWT+sc5rKLCOljnXwcXsxbmhrWwfQFj57wVWkvZTRNLfNZkcMnykw=,iv:JxCILR1qxAk391tTmLf/hXlr1L/JQWqhLbFHYR04HjI=,tag:0LSWWPWEBeK1Gm2mi4UBNA==,type:str]",
                "pgp": [
                        {
                                "created_at": "2018-01-14T14:52:38Z",
                                "enc": "-----BEGIN PGP MESSAGE-----\n\nwcFMA90gOM45xlRNARAAR+FmJBwY4gnpUUZSwWRrwJ+PLhBzVXoIfZ2zqhk+gkvl\nGZyi62mCM5ZVoVPf8Pw+a9cQi+IzJHgKEOT/6PIp1chw7DhnoGbFJExcE3inniou\nlLo2pFTRH5jTvCE3yIIR/l1b9VMrtnOcZuYx9SobLjIv4wKtY1gMkbmrG2IDLmMT\n9QYM/MT/aCcUA/u6bYz8+ZjAS7NUEifji/SkZkYlL1tdCEdiHU/Cl4gScOhqcIsK\nGWGa+1jnxnYOmYq3FDMb90RSPgU8xkzl9EQIInF2t4K3Zj7E+9J93Y7N2udpNGah\nebPwxS4VTCLl1p69q9+nhO8rn9ySjeTjIoJwPoNDzWVowQEmUPZCTz+A28RKi02l\nGsuYxCzD5aF8cRhZbLk882fCAo77U9TiYYa00cq8kTqnCpZmtp3BevrdWTswJwin\n/TID0DOflahzj7iUP8MAVI2nzGosmCWEFiVONWq2l2z7ND78Y65G/d5hM3zv71U/\n1z0B8zzxZSbFFTV2YjADwWdizpeXJFJuVdynCQdPxt8qfNZVXcQfIHmYwh4M3k3U\nv5yV491mwCPNAJAoBaNJoKLnXx3ae4Aic4s2sF3V+AKK6rNiWtuAWsyjuwzmTse2\ntQisNTez5m+6r5seC7YvC2i9Vb2DNzqYn4M/13tHjxpPrNxdCGNneM1FKG8a03nS\n4AHk5BBSjhL9oc/o7zf8AsoFdeE2A+BR4KnhNXbg2eJlJCnO4IvlzVv3wYVwmh5W\nfyHqIQAX3ICb43o6Vo2/AGANvM5BdA3gX+ToyYFHsSMttWLz4zAUJWe04pRx0/rh\n73EA\n=0ON2\n-----END PGP MESSAGE-----",
                                "fp": "C8F69F5F7059C32B3328DFE48BE9D15D0B0D06EB"
                        }
                ],
                "unencrypted_suffix": "_unencrypted",
                "version": "3.0.0"
        }
}
```

Fixes #235