### PR TITLE
Default to Warn log level unless verbose flag is passed

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -344,9 +344,18 @@ func main() {
 			Name:  "shamir-secret-sharing-threshold",
 			Usage: "the number of master keys required to retrieve the data key with shamir",
 		},
+		cli.BoolFlag{
+			Name:  "verbose",
+			Usage: "Enable verbose logging output",
+		},
 	}, keyserviceFlags...)
 
 	app.Action = func(c *cli.Context) error {
+		if c.Bool("verbose") {
+			logging.SetLevel(logrus.DebugLevel)
+		} else {
+			logging.SetLevel(logrus.WarnLevel)
+		}
 		if c.NArg() < 1 {
 			return common.NewExitError("Error: no file specified", codes.NoFileSpecified)
 		}

--- a/gcpkms/keysource.go
+++ b/gcpkms/keysource.go
@@ -43,7 +43,7 @@ func (key *MasterKey) SetEncryptedDataKey(enc []byte) {
 func (key *MasterKey) Encrypt(dataKey []byte) error {
 	cloudkmsService, err := key.createCloudKMSService()
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Warn("Encryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Encryption failed")
 		return fmt.Errorf("Cannot create GCP KMS service: %v", err)
 	}
 	req := &cloudkms.EncryptRequest{
@@ -51,10 +51,10 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	}
 	resp, err := cloudkmsService.Projects.Locations.KeyRings.CryptoKeys.Encrypt(key.ResourceID, req).Do()
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Warn("Encryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Encryption failed")
 		return fmt.Errorf("Failed to call GCP KMS encryption service: %v", err)
 	}
-	log.WithField("resourceID", key.ResourceID).Warn("Encryption succeeded")
+	log.WithField("resourceID", key.ResourceID).Info("Encryption succeeded")
 	key.EncryptedKey = resp.Ciphertext
 	return nil
 }
@@ -71,7 +71,7 @@ func (key *MasterKey) EncryptIfNeeded(dataKey []byte) error {
 func (key *MasterKey) Decrypt() ([]byte, error) {
 	cloudkmsService, err := key.createCloudKMSService()
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Warn("Decryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Decryption failed")
 		return nil, fmt.Errorf("Cannot create GCP KMS service: %v", err)
 	}
 
@@ -80,15 +80,15 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	}
 	resp, err := cloudkmsService.Projects.Locations.KeyRings.CryptoKeys.Decrypt(key.ResourceID, req).Do()
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Warn("Decryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Decryption failed")
 		return nil, fmt.Errorf("Error decrypting key: %v", err)
 	}
 	encryptedKey, err := base64.StdEncoding.DecodeString(resp.Plaintext)
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Warn("Decryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Decryption failed")
 		return nil, err
 	}
-	log.WithField("resourceID", key.ResourceID).Warn("Decryption succeeded")
+	log.WithField("resourceID", key.ResourceID).Info("Decryption succeeded")
 	return encryptedKey, nil
 }
 

--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -61,14 +61,14 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	if kmsSvc == nil || !isMocked {
 		sess, err := key.createSession()
 		if err != nil {
-			log.WithField("arn", key.Arn).Warn("Encryption failed")
+			log.WithField("arn", key.Arn).Info("Encryption failed")
 			return fmt.Errorf("Failed to create session: %v", err)
 		}
 		kmsSvc = kms.New(sess)
 	}
 	out, err := kmsSvc.Encrypt(&kms.EncryptInput{Plaintext: dataKey, KeyId: &key.Arn, EncryptionContext: key.EncryptionContext})
 	if err != nil {
-		log.WithField("arn", key.Arn).Warn("Encryption failed")
+		log.WithField("arn", key.Arn).Info("Encryption failed")
 		return fmt.Errorf("Failed to call KMS encryption service: %v", err)
 	}
 	key.EncryptedKey = base64.StdEncoding.EncodeToString(out.CiphertextBlob)
@@ -88,7 +88,7 @@ func (key *MasterKey) EncryptIfNeeded(dataKey []byte) error {
 func (key *MasterKey) Decrypt() ([]byte, error) {
 	k, err := base64.StdEncoding.DecodeString(key.EncryptedKey)
 	if err != nil {
-		log.WithField("arn", key.Arn).Warn("Decryption failed")
+		log.WithField("arn", key.Arn).Info("Decryption failed")
 		return nil, fmt.Errorf("Error base64-decoding encrypted data key: %s", err)
 	}
 	// isMocked is set by unit test to indicate that the KMS service
@@ -96,14 +96,14 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	if kmsSvc == nil || !isMocked {
 		sess, err := key.createSession()
 		if err != nil {
-			log.WithField("arn", key.Arn).Warn("Decryption failed")
+			log.WithField("arn", key.Arn).Info("Decryption failed")
 			return nil, fmt.Errorf("Error creating AWS session: %v", err)
 		}
 		kmsSvc = kms.New(sess)
 	}
 	decrypted, err := kmsSvc.Decrypt(&kms.DecryptInput{CiphertextBlob: k, EncryptionContext: key.EncryptionContext})
 	if err != nil {
-		log.WithField("arn", key.Arn).Warn("Decryption failed")
+		log.WithField("arn", key.Arn).Info("Decryption failed")
 		return nil, fmt.Errorf("Error decrypting key: %v", err)
 	}
 	log.WithField("arn", key.Arn).Info("Decryption succeeded")
@@ -221,6 +221,7 @@ func (key MasterKey) ToMap() map[string]interface{} {
 
 // ParseKMSContext takes either a KMS context map or a comma-separated list of KMS context key:value pairs and returns a map
 func ParseKMSContext(in interface{}) map[string]*string {
+	nonStringValueWarning := "Encryption context contains a non-string value, context will not be used"
 	out := make(map[string]*string)
 
 	switch in := in.(type) {
@@ -231,7 +232,7 @@ func ParseKMSContext(in interface{}) map[string]*string {
 		for k, v := range in {
 			value, ok := v.(string)
 			if !ok {
-				log.Warn("Encryption context contains a non-string value, context will not be used")
+				log.Warn(nonStringValueWarning)
 				return nil
 			}
 			out[k] = &value
@@ -243,12 +244,12 @@ func ParseKMSContext(in interface{}) map[string]*string {
 		for k, v := range in {
 			key, ok := k.(string)
 			if !ok {
-				log.Warn("Encryption context contains a non-string value, context will not be used")
+				log.Warn(nonStringValueWarning)
 				return nil
 			}
 			value, ok := v.(string)
 			if !ok {
-				log.Warn("Encryption context contains a non-string value, context will not be used")
+				log.Warn(nonStringValueWarning)
 				return nil
 			}
 			out[key] = &value
@@ -260,7 +261,7 @@ func ParseKMSContext(in interface{}) map[string]*string {
 		for _, kv := range strings.Split(in, ",") {
 			kv := strings.Split(kv, ":")
 			if len(kv) != 2 {
-				log.Warn("Encryption context contains a non-string value, context will not be used")
+				log.Warn(nonStringValueWarning)
 				return nil
 			}
 			out[kv[0]] = &kv[1]

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -32,4 +32,10 @@ func NewLogger(name string) *logrus.Logger {
 	return log
 }
 
+func SetLevel(level logrus.Level) {
+	for k := range Loggers {
+		Loggers[k].SetLevel(level)
+	}
+}
+
 var Loggers map[string]*logrus.Logger

--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -163,7 +163,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 		log.WithField("fingerprint", key.Fingerprint).Info("Encryption succeeded")
 		return nil
 	}
-	log.WithField("fingerprint", key.Fingerprint).Warn("Encryption failed")
+	log.WithField("fingerprint", key.Fingerprint).Info("Encryption failed")
 	return fmt.Errorf(
 		`could not encrypt data key with PGP key: golang.org/x/crypto/openpgp error: %v; GPG binary error: %v`,
 		openpgpErr, binaryErr)
@@ -225,7 +225,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 		log.WithField("fingerprint", key.Fingerprint).Info("Decryption succeeded")
 		return dataKey, nil
 	}
-	log.WithField("fingerprint", key.Fingerprint).Warn("Decryption failed")
+	log.WithField("fingerprint", key.Fingerprint).Info("Decryption failed")
 	return nil, fmt.Errorf(
 		`could not decrypt data key with PGP key: golang.org/x/crypto/openpgp error: %v; GPG binary error: %v`,
 		openpgpErr, binaryErr)

--- a/sops.go
+++ b/sops.go
@@ -335,7 +335,7 @@ func (tree Tree) Decrypt(key []byte, cipher Cipher) (string, error) {
 				if err != nil {
 					// Assume the comment was not encrypted in the first place
 					log.WithField("comment", c.Value).
-						Warn("Found possibly unencrypted field in file. " +
+						Warn("Found possibly unencrypted comment in file. " +
 							"This is to be expected if the file being " +
 							"decrypted was created with an older version of " +
 							"SOPS.")


### PR DESCRIPTION
Sets the default log level to `Warn` unless the `--verbose` path is specified. The `-v` shorthand could not be used due to it already being used by `--version`.

Things that will still log even without the `--verbose` flag:

- Specifying a non-string encryption context for KMS (I don't think this should be silently ignored)
- Unencrypted comments in files
- Providing invalid keyservice URIs

Example without `--verbose`, with both a key I can encrypt with but can't decrypt with, and a key I can encrypt and decrypt with:

```
~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ cat <<EOF > foo.yaml
foo: bar
EOF

~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ sops -e foo.yaml | tee foo.enc.yaml
foo: ENC[AES256_GCM,data:vhkY,iv:k36Hp3sfDWJPv8MtztigsPrvsH25Yqk79O8lcSvoa6o=,tag:9edQ+/9F/nZC6ETgmgdjTg==,type:str]
sops:
    kms: []
    gcp_kms: []
    lastmodified: '2018-03-07T16:32:08Z'
    mac: ENC[AES256_GCM,data:sySriifOm/1xE25TOaSaUVufLJGSdaClxsmx4vG3wvbKzM93Si2t02Qcri0XUmWfyk3c/Xmh4epGQ5cI+MjvIju89RFN5tziG+gNgEFZlg3vRWYlf0JRPqq5vU9Wox31jPDJyyHAYr/F2TrScZG+DtH5NlA5i2mUxeyD4RHrR00=,iv:Yebt7ZJJDjSvRnVxoGD74GvP59XIddGq1dbql8oE3F4=,tag:nj9tkqy6xQWpxymhx83MFw==,type:str]
    pgp:
    -   created_at: '2018-03-07T16:32:08Z'
        enc: |
            -----BEGIN PGP MESSAGE-----

            hQGMA3ewk3gjhW6kAQwAh5NSuSHd90RT4oi+Ya6GKp9Z/86D0vNHZdu48nDlO5Fr
            QOiBOLHG8fEvbgi3512wk+EpaCWAuqBnkNj5DcZVb5SXbpZSdipMfXBI4xkn8tck
            NHFmgZQlIwz3WHpHUAXC2g+TKhOSjHDKrygDXslu30STDXn0BEk/rSFusMwTqJ4O
            gljCDtsvhgUqJBHZnDcdQ5O6rgFJ8phvyRiKuvVT8EG8qAC94HAILaloH0ai5l6t
            Z1xjjAwT2bDf2D3zVjsq6vyI5c/aBHberlph/9EELKzgkWdHE4XJ7xAPPRNE0ahN
            QN5EWMGqh+JPkQ8uJksNZDXtKpGDp7DgtLrD87zVGvkJX0kaSyhmHquoLyx7uQWd
            VrKyXd1RYb6Rpqe3FevP5jEUm+CwepeBRQvVqry8CmcRiwd/EzUh1JYfVwA7BY5p
            QOxa3fT/4a7Jan8RPT38ouCteXtjnugU43FoHNqlTXbF4z9rg1dKQ15vwF7b8684
            R9okxbHCPAzOw2DndXnL0lwBvhBxrnpPui+ru61WGdSa96IUoq0LZGR/bV+PUG95
            Ge01v++WImBBSRZNIadkxUalY2rw2G9nJeZEOx+8715knip36EKxJaabF5BboUmO
            5MngE2H08iJFkK+wdg==
            =YSPE
            -----END PGP MESSAGE-----
        fp: 6F73539153B31C193A2154EAF7A9B793541A953D
    -   created_at: '2018-03-07T16:32:08Z'
        enc: |
            -----BEGIN PGP MESSAGE-----

            hIwDEEVDpnzXnMABBACraBD9t7Wyya/sQ9nx93uLzDFZtCbFGWp0ORjZfW9ypAdF
            Jnn0Xy3oiDNCU8v5X/V9HtkPhdXH/foKVfK2h95gMdsZdzhFupzHtw91NUovJXiB
            g5SlvW6mCGsEh9UJceZpmNVOjUpSCj1R6v0FLwmSIywbG/gxqFTRBSQNiUV1gdJc
            AXGm6UJ0sRD0VNTSJfcmOla7+xbqqSUHYO3Jr77BOP/OaBLkwVO86c11JbNwkQYn
            qQGs1ZgRjOtczgqOIHSwgicK0NAZw/JCqy8rlQNpM3EQv90zPU96YDcZxCw=
            =ltur
            -----END PGP MESSAGE-----
        fp: 1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A
    unencrypted_suffix: _unencrypted
    version: 3.0.0

~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ sops -d foo.enc.yaml
foo: bar
```

And with `--verbose`:

```
~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ cat <<EOF > foo.yaml
foo: bar
EOF

~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ sops --verbose -e foo.yaml | tee foo.enc.yaml
[PGP]	 INFO[0000] Encryption succeeded                          fingerprint=6F73539153B31C193A2154EAF7A9B793541A953D
[PGP]	 INFO[0000] Encryption succeeded                          fingerprint=1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A
foo: ENC[AES256_GCM,data:HJHm,iv:1lM1hCHoWVjKE0yWFn9nqENAh5RDJhJoy2aOvcopdyk=,tag:3wRlsxpHWGiqyEynwNinDQ==,type:str]
sops:
    kms: []
    gcp_kms: []
    lastmodified: '2018-03-07T16:32:56Z'
    mac: ENC[AES256_GCM,data:oZiuRPybsiuSclLU4u/5tDoAPUvlOSF24pN+bpSBOOSwx3DA3a9GhUlNXFzgPROfDRcsZSZwdH832pNhcHqtBM2b/jPQkc7DjOKpmbc1RVX8ydBvAf5oK5Jn9JA5pvrn+3MH08Aiix9HaxdhcoJmb5ESJf7jjceBWqHcvtJqU9s=,iv:ZLMhEfHOtnIKYjbsEJWNq3BBQvB6jqZAQjCQD93j3lQ=,tag:rWywxre0z/rFOesDyy4RrQ==,type:str]
    pgp:
    -   created_at: '2018-03-07T16:32:56Z'
        enc: |
            -----BEGIN PGP MESSAGE-----

            hQGMA3ewk3gjhW6kAQv/eu3uWhNzg387gQznHjcEPrC2Yii9VPS/Znhp4/Htq/Pr
            9+lRaT5T2S/7FuKrI4xhWRNu7YaCSRzYuQ36O+UCIYvNlMTOnJhlZefytWGJrzOT
            BZMnQ1OXFGiieCZny1i9dbEOyUxFFBLWs0UkGZBgAuUJqXNrw+xaY1nX3389SbEH
            olnBVI2jzmqf1Hzl0YBH7xxpHs1UtnTkZ+nax0+xdQMEBfp9PONh2vMSTDjDUYqu
            7ZU91TOd42SWPYqvTOASO+gDP8R8IDSG+DGduLUq6xaGkmQtiuw3bxua1LOoUxVy
            HwdFp7+qNQVWEkF81MbPrZqBR23LsqfRJkySEyhTDZbwyK2leFtbiOY3ujd+QoV6
            UY+g9iuCvvvMfkCj3vtio5uFV/o/c2ZYbwdxJS+D9w0AMtS/JOVplbHuC3+MUe78
            TkRFuJxSUwETGD1tt70VhFaybyd3UOSGXZ5mAoZGkXuvI3ufazC7Ez9bfOpwwtTx
            sCRQEkRavIW3N61eP+XU0lwB/3WJYcHCgnPyqEvD03Gv3awKuQV9QNYjYQRoC//J
            WSSQRUH3h0qL/CoWrrMQGhBD75o7iFX4PimZGjDNK5zMiyb/C/MNWhl1rYn4+ARD
            EP6JTof23MZO4Q159Q==
            =1TKI
            -----END PGP MESSAGE-----
        fp: 6F73539153B31C193A2154EAF7A9B793541A953D
    -   created_at: '2018-03-07T16:32:56Z'
        enc: |
            -----BEGIN PGP MESSAGE-----

            hIwDEEVDpnzXnMABA/9JHe7tOgaYNXowlOQM5XsAaNJ1h1MB+Y6M32t0P+sNmPQd
            /0YOuxZzPP8rzAGsKytfvYfcUU/Pk7ZtSmXcd8Q8gTC6gUYk+qrASbDh6WC5HXZu
            ULpSJ4/UB0zsuEkGzIEf38AwcTzUs8uXyw9XygrSLO9isoigJmzYpgCupsud3tJc
            Aa6DQNWEK2m/us/V80IbyIH7eLyc2jHf7akosaZUeIc0S4eJzngIAWdgag7FpGDc
            1byZ4KqEn8dcWfY1j+ejEDjwBcL766xx603cCsHDB68KnW2+TRr/96AccK4=
            =vIzN
            -----END PGP MESSAGE-----
        fp: 1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A
    unencrypted_suffix: _unencrypted
    version: 3.0.0

~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ sops --verbose -d foo.enc.yaml
[PGP]	 INFO[0000] Decryption failed                             fingerprint=6F73539153B31C193A2154EAF7A9B793541A953D
[PGP]	 INFO[0000] Decryption succeeded                          fingerprint=1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A
[SOPS]	 INFO[0000] Data key recovered successfully              
[SOPS]	 DEBU[0000] Decrypting tree                              
foo: bar
```

And of course, if decrypting fails for whichever reason (in this case because the file has no keys I can decrypt with), error messages are still shown even without `--verbose`:

```
~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ cat <<EOF > foo.yaml
foo: bar
EOF

~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ sops -e foo.yaml | tee foo.enc.yaml
foo: ENC[AES256_GCM,data:ATE7,iv:Skjc62g4FI5wzIHHBolWkiDkeCD/yJDi98BTINJtKrg=,tag:VDWk6+xJrZ70/ODv0njkPg==,type:str]
sops:
    kms: []
    gcp_kms: []
    lastmodified: '2018-03-07T16:33:48Z'
    mac: ENC[AES256_GCM,data:CjBN4PdMFby0MGFzQG1c5jLAnOcOanGwj90FSL8AKvJw2SJtI6GvdpVezTV9IClvfPgUOR8iMGI1yI+WBNDZM1uoc7I/Nw0AhT0gszgfoFNnF1LvIpH8VXvfSDo3MOUtTIP7JtqcmAi+Kc4G0nold941mBUlqfdSAdSooRz3lYY=,iv:y0GuWEw0/96X9eA9IS+00A4bNOjXFOClDtSCI5N41po=,tag:qrktIBx+N83EKSopiKTG/w==,type:str]
    pgp:
    -   created_at: '2018-03-07T16:33:47Z'
        enc: |
            -----BEGIN PGP MESSAGE-----

            hQGMA3ewk3gjhW6kAQwAieBj5qbkWsP1VxDmhregEoRa4NWSyj0VXEjPRKjmTY5Y
            HvABSicKOrmmXOhzuW6fgZbPds3cXruFOcU5TDwpvI9yLSm77GqMzNfGiEkjIDEa
            ekubLPhnjnyGs9F/bTo++u/D8XWmBlRY55kBwCYeCTA+qM6/Pi5gJLkvqPHUgQDS
            ALoKFzTEy0cgu4kCMzaAaxcW2jR+D83o8+xl7FJBHWQZfxnO2wcFgvnnCDh+uOoc
            dvGDYDrVHGRcAHB9Ec1voTO8GjyXUTqSmEA3S0XRolHnQ+1o5t6LmJXVSNemZwNV
            mNHpcW9JirGEV7Y1lyb1NuzQG5Hsvq4Mz0HUw3rRbMtZt0pUT+I3VBAAbgRACO2w
            RsYLcBiXujYOJSnlr2Nu62PpJsYx1iQ1Ch2AlnGKJ7hCwZ/mXzz8ITJp9AzmFxxi
            Y25V+CRS1zOzbZQHCJalX+y4Yz4RAWbKn+TyA+CbAdTcuTtjV3ulMihcO2k3h6Up
            VV+Tvojnu/m1l4y3L3u70lwBXVQSENRlMMaZ2Kn360tfJmcCee9xENpDxuyWBTRQ
            hVJCOyAhYc5dZMl9cxOtR+FFZFxlCeCj57j2jYCRcodKCe1+iEGqiiHzSfmtn/KR
            ZdoN4MLscSjoTf7UrQ==
            =bAva
            -----END PGP MESSAGE-----
        fp: 6F73539153B31C193A2154EAF7A9B793541A953D
    unencrypted_suffix: _unencrypted
    version: 3.0.0

~/Projects/go/src/go.mozilla.org/sops reduce-logging*
❯ sops -d foo.enc.yaml
Failed to get the data key required to decrypt the SOPS file.

Group 0: FAILED
  6F73539153B31C193A2154EAF7A9B793541A953D: FAILED
    - | could not decrypt data key with PGP key:
      | golang.org/x/crypto/openpgp error: Could not load secring:
      | open /Users/autrilla/.gnupg/secring.gpg: no such file or
      | directory; GPG binary error: exit status 2

Recovery failed because no master key was able to decrypt the file. In
order for SOPS to recover the file, at least one key has to be successful,
but none were.
```