### PR TITLE
publish statically-linked binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ before_deploy:
   - mkdir dist
   - make deb-pkg rpm-pkg
   - mv *.deb *.rpm dist/
-  - GOOS=darwin go build -o dist/sops-${TRAVIS_TAG}.darwin go.mozilla.org/sops/cmd/sops
-  - GOOS=windows go build -o dist/sops-${TRAVIS_TAG}.exe go.mozilla.org/sops/cmd/sops
-  - GOOS=linux go build -o dist/sops-${TRAVIS_TAG}.linux go.mozilla.org/sops/cmd/sops
+  - GOOS=darwin CGO_ENABLED=0 go build -o dist/sops-${TRAVIS_TAG}.darwin go.mozilla.org/sops/cmd/sops
+  - GOOS=windows CGO_ENABLED=0 go build -o dist/sops-${TRAVIS_TAG}.exe go.mozilla.org/sops/cmd/sops
+  - GOOS=linux CGO_ENABLED=0 go build -o dist/sops-${TRAVIS_TAG}.linux go.mozilla.org/sops/cmd/sops
 
 deploy:
   provider: releases


### PR DESCRIPTION
I am using helm-secrets in an alpine container, which calls sops under the hood. Obviously Alpine has uclibc installed, so the dynamically linked binaries against glibc that are published will not work.

Instead I am proposing we statically link the binaries across all platforms for portability.
