### PR TITLE
dont create the file if its empty

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -486,7 +486,7 @@ func main() {
 			} else {
 				// File doesn't exist, edit the example file instead
 				var groups []sops.KeyGroup
-				groups, err := keyGroups(c, fileName)
+				groups, err = keyGroups(c, fileName)
 				if err != nil {
 					return toExitError(err)
 				}
@@ -507,6 +507,7 @@ func main() {
 		if err != nil {
 			return toExitError(err)
 		}
+
 		// We open the file *after* the operations on the tree have been
 		// executed to avoid truncating it when there's errors
 		if c.Bool("in-place") || isEditMode || c.String("set") != "" {


### PR DESCRIPTION
Current experience when running `sops file.yaml` and exiting without saving anything creates an empty file that throws a `sops metadata not found` error if re-opened with sops.

As a user, I would expect if I didn't save a new file in my editor, then there shouldn't be a file created.

This PR attempts to correct that by just not creating the file if the resulting output from an edit session is empty.