### PR TITLE
deprecate filename_regex in favor of path_regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -396,17 +396,17 @@ can manage the three sets of configurations for the three types of files:
 	creation_rules:
 		# upon creation of a file that matches the pattern *.dev.yaml,
 		# KMS set A is used
-		- filename_regex: \.dev\.yaml$
+		- path_regex: \.dev\.yaml$
 		  kms: 'arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500,arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e+arn:aws:iam::361527076523:role/hiera-sops-prod'
 		  pgp: '1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A'
 
 		# prod files use KMS set B in the PROD IAM
-		- filename_regex: \.prod\.yaml$
+		- path_regex: \.prod\.yaml$
 		  kms: 'arn:aws:kms:us-west-2:361527076523:key/5052f06a-5d3f-489e-b86c-57201e06f31e+arn:aws:iam::361527076523:role/hiera-sops-prod,arn:aws:kms:eu-central-1:361527076523:key/cb1fab90-8d17-42a1-a9d8-334968904f94+arn:aws:iam::361527076523:role/hiera-sops-prod'
 		  pgp: '1022470DE3F0BC54BC6AB62DE05550BC07FB1A0A'
 
 		# gcp files using GCP KMS
-		- filename_regex: \.gcp\.yaml$
+		- path_regex: \.gcp\.yaml$
 		  gcp_kms: projects/mygcproject/locations/global/keyRings/mykeyring/cryptoKeys/thekey
 
 		# Finally, if the rules above have not matched, this one is a
@@ -484,7 +484,7 @@ like so:
 .. code:: yaml
 
     creation_rules:
-        - filename_regex: .*keygroups.*
+        - path_regex: .*keygroups.*
           key_groups:
           # First key group
           - pgp:
@@ -525,7 +525,7 @@ with `shamir_threshold`:
 .. code:: yaml
 
     creation_rules:
-        - filename_regex: .*keygroups.*
+        - path_regex: .*keygroups.*
           shamir_threshold: 2
           key_groups:
           # First key group


### PR DESCRIPTION
Firstly, I wanted to express how grateful we are for this tool. It's going to drastically change the way we do secrets management for the better across our engineering org. I was wondering if you think the following change is acceptable?

Currently, the `.sops.yaml` file takes an attribute called `filename_regex`. We've found that title to be a bit misleading as it also supports full directory paths as written.

This PR started out as simply an effort to document how we're currently using it with a test to make sure directory path support isn't later removed. Eventually, I ended up implementing [this comment](https://github.com/mozilla/sops/issues/77#issuecomment-237364812).

So what you see here is adding support for an attribute called `path_regex` that has the same behavior as `filename_regex` does today. `filename_regex` still works for backwards compatibility, but gets a message that it may later be removed when used.

I thought about using pointers instead of strings for the type assignment of these values to make the logic a bit easier to grok, but wanted to keep support for the case where the regex attribute isn't supplied at all in case anyone currently uses it that way.

Closes https://github.com/mozilla/sops/issues/77