### PR TITLE
Allow forcing binary input and output types through cli flags

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -285,11 +285,11 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "input-type",
-			Usage: "currently json and yaml are supported. If not set, sops will use the file's extension to determine the type",
+			Usage: "currently json, yaml and binary are supported. If not set, sops will use the file's extension to determine the type",
 		},
 		cli.StringFlag{
 			Name:  "output-type",
-			Usage: "currently json and yaml are supported. If not set, sops will use the input file's extension to determine the output format",
+			Usage: "currently json, yaml and binary are supported. If not set, sops will use the input file's extension to determine the output format",
 		},
 		cli.BoolFlag{
 			Name:  "show-master-keys, s",
@@ -579,6 +579,8 @@ func inputStore(context *cli.Context, path string) sops.Store {
 		return &yamlstores.Store{}
 	case "json":
 		return &json.Store{}
+	case "binary":
+		return &json.BinaryStore{}
 	default:
 		return common.DefaultStoreForPath(path)
 	}
@@ -589,6 +591,8 @@ func outputStore(context *cli.Context, path string) sops.Store {
 		return &yamlstores.Store{}
 	case "json":
 		return &json.Store{}
+	case "binary":
+		return &json.BinaryStore{}
 	default:
 		return common.DefaultStoreForPath(path)
 	}


### PR DESCRIPTION
For some reason we didn't support manually specifying binary input and output file types from cli args. No longer!