### PR TITLE
Don't yaml.MarshalValue strings on extract

### DIFF
--- a/cmd/sops/decrypt.go
+++ b/cmd/sops/decrypt.go
@@ -57,6 +57,8 @@ func extract(tree *sops.Tree, path []interface{}, outputStore sops.Store) (outpu
 			return nil, common.NewExitError(fmt.Sprintf("Error dumping file: %s", err), codes.ErrorDumpingTree)
 		}
 		return decrypted, err
+	} else if str, ok := v.(string); ok {
+		return []byte(str), nil
 	}
 	bytes, err := outputStore.MarshalValue(v)
 	if err != nil {

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -358,4 +358,31 @@ b: ba"#
                     .success(),
                 "SOPS failed to decrypt a file that uses multiple keys");
     }
+
+
+    #[test]
+    fn extract_string() {
+        let file_path = prepare_temp_file("test_extract_string.yaml",
+                                          "multiline: |\n  multi\n  line".as_bytes());
+        let output = Command::new(SOPS_BINARY_PATH)
+            .arg("-i")
+            .arg("-e")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops");
+        assert!(output.status.success(), "SOPS failed to encrypt a file");
+        let output = Command::new(SOPS_BINARY_PATH)
+            .arg("--extract")
+            .arg("[\"multiline\"]")
+            .arg("-d")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops");
+        assert!(output.status
+                    .success(),
+                "SOPS failed to extract");
+
+        assert_eq!(output.stdout, b"multi\nline");
+    }
+
 }


### PR DESCRIPTION
When using --extract with multi-line strings, the behavior doesn't match the docs:

```
~/Projects/go/src/go.mozilla.org/sops extract-string*
❯ sops -d foo.yaml 
hello: |
    multi-line
    string

~/Projects/go/src/go.mozilla.org/sops extract-string*
❯ sops -d --extract '["hello"]' foo.yaml                    
|
    multi-line
    string

```

When the output value is already a string, there is no need to pass it through `yaml.MarshalValue`, and doing so will change the result if for example the string contains new lines. This makes it annoying to build shell pipelines using --extract, as you have to pipe it through something that removes yaml formatting.

With this patch:

```
~/Projects/go/src/go.mozilla.org/sops extract-string*
❯ sops -d --extract '["hello"]' foo.yaml
multi-line
string

```