### PR TITLE
Added an --encrypted-suffix option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -894,6 +894,11 @@ breaking the file integrity check.
 The unencrypted suffix can be set to a different value using the
 `--unencrypted-suffix` option.
 
+Conversely, you can opt in to only encrypt some values in a YAML or JSON file,
+by adding a chosen suffix to those keys and passing it to the `--encrypted-suffix` option.
+
+These two options `--unencrypted-suffix` and `--encrypted-suffix` cannot both be used in the same file.
+
 Encryption Protocol
 -------------------
 

--- a/cmd/sops/codes/codes.go
+++ b/cmd/sops/codes/codes.go
@@ -10,6 +10,7 @@ const (
 	ErrorReadingConfig                     int = 5
 	ErrorInvalidKMSEncryptionContextFormat int = 6
 	ErrorInvalidSetFormat                  int = 7
+	ErrorConflictingParameters             int = 8
 	ErrorEncryptingMac                     int = 21
 	ErrorEncryptingTree                    int = 23
 	ErrorDecryptingMac                     int = 24

--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -36,6 +36,7 @@ type editOpts struct {
 type editExampleOpts struct {
 	editOpts
 	UnencryptedSuffix string
+	EncryptedSuffix   string
 	KeyGroups         []sops.KeyGroup
 	GroupThreshold    int
 }
@@ -96,6 +97,7 @@ func editExample(opts editExampleOpts) ([]byte, error) {
 	tree.Metadata = sops.Metadata{
 		KeyGroups:         opts.KeyGroups,
 		UnencryptedSuffix: opts.UnencryptedSuffix,
+		EncryptedSuffix:   opts.EncryptedSuffix,
 		Version:           version,
 		ShamirThreshold:   opts.GroupThreshold,
 	}

--- a/cmd/sops/encrypt.go
+++ b/cmd/sops/encrypt.go
@@ -18,6 +18,7 @@ type encryptOpts struct {
 	InputPath         string
 	KeyServices       []keyservice.KeyServiceClient
 	UnencryptedSuffix string
+	EncryptedSuffix   string
 	KeyGroups         []sops.KeyGroup
 	GroupThreshold    int
 }
@@ -37,6 +38,7 @@ func encrypt(opts encryptOpts) (encryptedFile []byte, err error) {
 	tree.Metadata = sops.Metadata{
 		KeyGroups:         opts.KeyGroups,
 		UnencryptedSuffix: opts.UnencryptedSuffix,
+		EncryptedSuffix:   opts.EncryptedSuffix,
 		Version:           version,
 		ShamirThreshold:   opts.GroupThreshold,
 	}

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -329,6 +329,10 @@ func main() {
 			Value: sops.DefaultUnencryptedSuffix,
 		},
 		cli.StringFlag{
+			Name:  "encrypted-suffix",
+			Usage: "override the encrypted key suffix. When empty, all keys will be encrypted, unless otherwise marked with unencrypted-suffix.",
+		},
+		cli.StringFlag{
 			Name:  "config",
 			Usage: "path to sops' config file. If set, sops will not search for the config file recursively.",
 		},
@@ -392,6 +396,7 @@ func main() {
 				InputPath:         fileName,
 				Cipher:            aes.NewCipher(),
 				UnencryptedSuffix: c.String("unencrypted-suffix"),
+				EncryptedSuffix:   c.String("encrypted-suffix"),
 				KeyServices:       svcs,
 				KeyGroups:         groups,
 				GroupThreshold:    threshold,
@@ -498,6 +503,7 @@ func main() {
 				output, err = editExample(editExampleOpts{
 					editOpts:          opts,
 					UnencryptedSuffix: c.String("unencrypted-suffix"),
+					EncryptedSuffix:   c.String("encrypted-suffix"),
 					KeyGroups:         groups,
 					GroupThreshold:    threshold,
 				})

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -326,7 +326,6 @@ func main() {
 		cli.StringFlag{
 			Name:  "unencrypted-suffix",
 			Usage: "override the unencrypted key suffix.",
-			Value: sops.DefaultUnencryptedSuffix,
 		},
 		cli.StringFlag{
 			Name:  "encrypted-suffix",
@@ -366,11 +365,21 @@ func main() {
 		fileName := c.Args()[0]
 		if _, err := os.Stat(fileName); os.IsNotExist(err) {
 			if c.String("add-kms") != "" || c.String("add-pgp") != "" || c.String("add-gcp-kms") != "" || c.String("rm-kms") != "" || c.String("rm-pgp") != "" || c.String("rm-gcp-kms") != "" {
-				return common.NewExitError("Error: cannot add or remove keys on non-existent files, use `--kms` and `--pgp` instead.", 49)
+				return common.NewExitError("Error: cannot add or remove keys on non-existent files, use `--kms` and `--pgp` instead.", codes.CannotChangeKeysFromNonExistentFile)
 			}
 			if c.Bool("encrypt") || c.Bool("decrypt") || c.Bool("rotate") {
 				return common.NewExitError("Error: cannot operate on non-existent file", codes.NoFileSpecified)
 			}
+		}
+
+		unencryptedSuffix := c.String("unencrypted-suffix")
+		encryptedSuffix := c.String("encrypted-suffix")
+		if unencryptedSuffix != "" && encryptedSuffix != "" {
+			return common.NewExitError("Error: cannot use both encrypted_suffix and unencrypted_suffix in the same file", codes.ErrorConflictingParameters)
+		}
+		// only supply the default UnencryptedSuffix when EncryptedSuffix is not provided
+		if unencryptedSuffix == "" && encryptedSuffix == "" {
+			unencryptedSuffix = sops.DefaultUnencryptedSuffix
 		}
 
 		inputStore := inputStore(c, fileName)
@@ -395,8 +404,8 @@ func main() {
 				InputStore:        inputStore,
 				InputPath:         fileName,
 				Cipher:            aes.NewCipher(),
-				UnencryptedSuffix: c.String("unencrypted-suffix"),
-				EncryptedSuffix:   c.String("encrypted-suffix"),
+				UnencryptedSuffix: unencryptedSuffix,
+				EncryptedSuffix:   encryptedSuffix,
 				KeyServices:       svcs,
 				KeyGroups:         groups,
 				GroupThreshold:    threshold,
@@ -502,8 +511,8 @@ func main() {
 				}
 				output, err = editExample(editExampleOpts{
 					editOpts:          opts,
-					UnencryptedSuffix: c.String("unencrypted-suffix"),
-					EncryptedSuffix:   c.String("encrypted-suffix"),
+					UnencryptedSuffix: unencryptedSuffix,
+					EncryptedSuffix:   encryptedSuffix,
 					KeyGroups:         groups,
 					GroupThreshold:    threshold,
 				})

--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -90,7 +90,7 @@ func getKeyFromKeyServer(keyserver string, fingerprint string) (openpgp.Entity, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return openpgp.Entity{}, fmt.Errorf("keyserver returned non-200 status code %d", resp.Status)
+		return openpgp.Entity{}, fmt.Errorf("keyserver returned non-200 status code %s", resp.Status)
 	}
 	ents, err := openpgp.ReadArmoredKeyRing(resp.Body)
 	if err != nil {

--- a/sops.go
+++ b/sops.go
@@ -107,7 +107,7 @@ func valueFromPathAndLeaf(path []interface{}, leaf interface{}) interface{} {
 				leaf,
 			}
 		} else {
-			return []interface{} {
+			return []interface{}{
 				valueFromPathAndLeaf(path[1:], leaf),
 			}
 		}
@@ -115,14 +115,14 @@ func valueFromPathAndLeaf(path []interface{}, leaf interface{}) interface{} {
 		if len(path) == 1 {
 			return TreeBranch{
 				TreeItem{
-					Key: component,
+					Key:   component,
 					Value: leaf,
 				},
 			}
 		} else {
 			return TreeBranch{
 				TreeItem{
-					Key: component,
+					Key:   component,
 					Value: valueFromPathAndLeaf(path[1:], leaf),
 				},
 			}
@@ -171,7 +171,7 @@ func set(branch interface{}, path []interface{}, value interface{}) interface{} 
 	}
 }
 
-func (branch TreeBranch) Set(path []interface{}, value interface{}) (TreeBranch) {
+func (branch TreeBranch) Set(path []interface{}, value interface{}) TreeBranch {
 	return set(branch, path, value).(TreeBranch)
 }
 
@@ -281,7 +281,8 @@ func (branch TreeBranch) walkBranch(in TreeBranch, path []string, onLeaves func(
 	return in, nil
 }
 
-// Encrypt walks over the tree and encrypts all values with the provided cipher, except those whose key ends with the UnencryptedSuffix specified on the Metadata struct. If encryption is successful, it returns the MAC for the encrypted tree.
+// Encrypt walks over the tree and encrypts all values with the provided cipher, except those whose key ends with the UnencryptedSuffix specified on the Metadata struct, or those not ending with EncryptedSuffix, if EncryptedSuffix is provided (by default it is not).
+// If encryption is successful, it returns the MAC for the encrypted tree.
 func (tree Tree) Encrypt(key []byte, cipher Cipher) (string, error) {
 	hash := sha512.New()
 	_, err := tree.Branch.walkBranch(tree.Branch, make([]string, 0), func(in interface{}, path []string) (interface{}, error) {
@@ -294,10 +295,26 @@ func (tree Tree) Encrypt(key []byte, cipher Cipher) (string, error) {
 			hash.Write(bytes)
 		}
 		encrypted := true
-		for _, v := range path {
-			if strings.HasSuffix(v, tree.Metadata.UnencryptedSuffix) {
-				encrypted = false
+		if tree.Metadata.UnencryptedSuffix != "" {
+			for _, v := range path {
+				if strings.HasSuffix(v, tree.Metadata.UnencryptedSuffix) {
+					encrypted = false
+					break
+				}
 			}
+		}
+		if tree.Metadata.EncryptedSuffix != "" {
+			encryptedSuffixFound := false
+			for _, v := range path {
+				if strings.HasSuffix(v, tree.Metadata.EncryptedSuffix) {
+					encryptedSuffixFound = true
+					if !encrypted {
+						return nil, fmt.Errorf("Cannot use both encrypted_suffix and unencrypted_suffix in the same file")
+					}
+					break
+				}
+			}
+			encrypted = encryptedSuffixFound
 		}
 		if encrypted {
 			var err error
@@ -315,16 +332,33 @@ func (tree Tree) Encrypt(key []byte, cipher Cipher) (string, error) {
 	return fmt.Sprintf("%X", hash.Sum(nil)), nil
 }
 
-// Decrypt walks over the tree and decrypts all values with the provided cipher, except those whose key ends with the UnencryptedSuffix specified on the Metadata struct. If decryption is successful, it returns the MAC for the decrypted tree.
+// Decrypt walks over the tree and decrypts all values with the provided cipher, except those whose key ends with the UnencryptedSuffix specified on the Metadata struct or those not ending with EncryptedSuffix, if EncryptedSuffix is provided (by default it is not).
+// If decryption is successful, it returns the MAC for the decrypted tree.
 func (tree Tree) Decrypt(key []byte, cipher Cipher) (string, error) {
 	log.Debug("Decrypting tree")
 	hash := sha512.New()
 	_, err := tree.Branch.walkBranch(tree.Branch, make([]string, 0), func(in interface{}, path []string) (interface{}, error) {
 		encrypted := true
-		for _, p := range path {
-			if strings.HasSuffix(p, tree.Metadata.UnencryptedSuffix) {
-				encrypted = false
+		if tree.Metadata.UnencryptedSuffix != "" {
+			for _, p := range path {
+				if strings.HasSuffix(p, tree.Metadata.UnencryptedSuffix) {
+					encrypted = false
+					break
+				}
 			}
+		}
+		if tree.Metadata.EncryptedSuffix != "" {
+			encryptedSuffixFound := false
+			for _, p := range path {
+				if strings.HasSuffix(p, tree.Metadata.EncryptedSuffix) {
+					encryptedSuffixFound = true
+					if !encrypted {
+						return nil, fmt.Errorf("Cannot use both encrypted_suffix and unencrypted_suffix in the same file")
+					}
+					break
+				}
+			}
+			encrypted = encryptedSuffixFound
 		}
 		var v interface{}
 		if encrypted {
@@ -390,6 +424,7 @@ func (tree *Tree) GenerateDataKeyWithKeyServices(svcs []keyservice.KeyServiceCli
 type Metadata struct {
 	LastModified              time.Time
 	UnencryptedSuffix         string
+	EncryptedSuffix           string
 	MessageAuthenticationCode string
 	Version                   string
 	KeyGroups                 []KeyGroup

--- a/sops.go
+++ b/sops.go
@@ -304,17 +304,13 @@ func (tree Tree) Encrypt(key []byte, cipher Cipher) (string, error) {
 			}
 		}
 		if tree.Metadata.EncryptedSuffix != "" {
-			encryptedSuffixFound := false
+			encrypted = false
 			for _, v := range path {
 				if strings.HasSuffix(v, tree.Metadata.EncryptedSuffix) {
-					encryptedSuffixFound = true
-					if !encrypted {
-						return nil, fmt.Errorf("Cannot use both encrypted_suffix and unencrypted_suffix in the same file")
-					}
+					encrypted = true
 					break
 				}
 			}
-			encrypted = encryptedSuffixFound
 		}
 		if encrypted {
 			var err error
@@ -348,17 +344,13 @@ func (tree Tree) Decrypt(key []byte, cipher Cipher) (string, error) {
 			}
 		}
 		if tree.Metadata.EncryptedSuffix != "" {
-			encryptedSuffixFound := false
+			encrypted = false
 			for _, p := range path {
 				if strings.HasSuffix(p, tree.Metadata.EncryptedSuffix) {
-					encryptedSuffixFound = true
-					if !encrypted {
-						return nil, fmt.Errorf("Cannot use both encrypted_suffix and unencrypted_suffix in the same file")
-					}
+					encrypted = true
 					break
 				}
 			}
-			encrypted = encryptedSuffixFound
 		}
 		var v interface{}
 		if encrypted {

--- a/sops_test.go
+++ b/sops_test.go
@@ -83,6 +83,56 @@ func TestUnencryptedSuffix(t *testing.T) {
 	}
 }
 
+func TestEncryptedSuffix(t *testing.T) {
+	branch := TreeBranch{
+		TreeItem{
+			Key:   "foo_encrypted",
+			Value: "bar",
+		},
+		TreeItem{
+			Key: "bar",
+			Value: TreeBranch{
+				TreeItem{
+					Key:   "foo",
+					Value: "bar",
+				},
+			},
+		},
+	}
+	tree := Tree{Branch: branch, Metadata: Metadata{EncryptedSuffix: "_encrypted"}}
+	expected := TreeBranch{
+		TreeItem{
+			Key:   "foo_encrypted",
+			Value: "rab",
+		},
+		TreeItem{
+			Key: "bar",
+			Value: TreeBranch{
+				TreeItem{
+					Key:   "foo",
+					Value: "bar",
+				},
+			},
+		},
+	}
+	cipher := reverseCipher{}
+	_, err := tree.Encrypt(bytes.Repeat([]byte("f"), 32), cipher)
+	if err != nil {
+		t.Errorf("Encrypting the tree failed: %s", err)
+	}
+	if !reflect.DeepEqual(tree.Branch, expected) {
+		t.Errorf("Trees don't match: \ngot \t\t%+v,\n expected \t\t%+v", tree.Branch, expected)
+	}
+	_, err = tree.Decrypt(bytes.Repeat([]byte("f"), 32), cipher)
+	if err != nil {
+		t.Errorf("Decrypting the tree failed: %s", err)
+	}
+	expected[0].Value = "bar"
+	if !reflect.DeepEqual(tree.Branch, expected) {
+		t.Errorf("Trees don't match: \ngot\t\t\t%+v,\nexpected\t\t%+v", tree.Branch, expected)
+	}
+}
+
 type MockCipher struct{}
 
 func (m MockCipher) Encrypt(value interface{}, key []byte, path string) (string, error) {
@@ -248,7 +298,6 @@ func TestTruncateTree(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-
 func TestEncryptComments(t *testing.T) {
 	tree := Tree{
 		Branch: TreeBranch{
@@ -327,7 +376,7 @@ func TestSetNewKey(t *testing.T) {
 					Key: "bar",
 					Value: TreeBranch{
 						TreeItem{
-							Key: "baz",
+							Key:   "baz",
 							Value: "foobar",
 						},
 					},
@@ -356,14 +405,13 @@ func TestSetArrayDeepNew(t *testing.T) {
 func TestSetNewKeyDeep(t *testing.T) {
 	branch := TreeBranch{
 		TreeItem{
-			Key: "foo",
+			Key:   "foo",
 			Value: "bar",
 		},
 	}
 	set := branch.Set([]interface{}{"foo", "bar", "baz"}, "hello")
 	assert.Equal(t, "hello", set[0].Value.(TreeBranch)[0].Value.(TreeBranch)[0].Value)
 }
-
 
 func TestSetNewKeyOnEmptyBranch(t *testing.T) {
 	branch := TreeBranch{}
@@ -386,7 +434,6 @@ func TestSetArray(t *testing.T) {
 	assert.Equal(t, "uno", set[0].Value.([]interface{})[0])
 }
 
-
 func TestSetArrayNew(t *testing.T) {
 	branch := TreeBranch{}
 	set := branch.Set([]interface{}{"foo", 0, 0}, "uno")
@@ -396,7 +443,7 @@ func TestSetArrayNew(t *testing.T) {
 func TestSetExisting(t *testing.T) {
 	branch := TreeBranch{
 		TreeItem{
-			Key: "foo",
+			Key:   "foo",
 			Value: "foobar",
 		},
 	}
@@ -407,7 +454,7 @@ func TestSetExisting(t *testing.T) {
 func TestSetArrayLeafNewItem(t *testing.T) {
 	branch := TreeBranch{
 		TreeItem{
-			Key: "array",
+			Key:   "array",
 			Value: []interface{}{},
 		},
 	}
@@ -438,7 +485,7 @@ func TestSetArrayNonLeaf(t *testing.T) {
 			Value: []interface{}{
 				TreeBranch{
 					TreeItem{
-						Key: "hello",
+						Key:   "hello",
 						Value: "hello",
 					},
 				},

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -42,6 +42,7 @@ type Metadata struct {
 	MessageAuthenticationCode string      `yaml:"mac" json:"mac"`
 	PGPKeys                   []pgpkey    `yaml:"pgp" json:"pgp"`
 	UnencryptedSuffix         string      `yaml:"unencrypted_suffix" json:"unencrypted_suffix"`
+	EncryptedSuffix           string      `yaml:"encrypted_suffix,omitempty" json:"encrypted_suffix,omitempty"`
 	Version                   string      `yaml:"version" json:"version"`
 }
 
@@ -76,6 +77,7 @@ func MetadataFromInternal(sopsMetadata sops.Metadata) Metadata {
 	var m Metadata
 	m.LastModified = sopsMetadata.LastModified.Format(time.RFC3339)
 	m.UnencryptedSuffix = sopsMetadata.UnencryptedSuffix
+	m.EncryptedSuffix = sopsMetadata.EncryptedSuffix
 	m.MessageAuthenticationCode = sopsMetadata.MessageAuthenticationCode
 	m.Version = sopsMetadata.Version
 	m.ShamirThreshold = sopsMetadata.ShamirThreshold
@@ -159,6 +161,7 @@ func (m *Metadata) ToInternal() (sops.Metadata, error) {
 		Version:                   m.Version,
 		MessageAuthenticationCode: m.MessageAuthenticationCode,
 		UnencryptedSuffix:         m.UnencryptedSuffix,
+		EncryptedSuffix:           m.EncryptedSuffix,
 		LastModified:              lastModified,
 	}, nil
 }

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -41,7 +41,7 @@ type Metadata struct {
 	LastModified              string      `yaml:"lastmodified" json:"lastmodified"`
 	MessageAuthenticationCode string      `yaml:"mac" json:"mac"`
 	PGPKeys                   []pgpkey    `yaml:"pgp" json:"pgp"`
-	UnencryptedSuffix         string      `yaml:"unencrypted_suffix" json:"unencrypted_suffix"`
+	UnencryptedSuffix         string      `yaml:"unencrypted_suffix,omitempty" json:"unencrypted_suffix,omitempty"`
 	EncryptedSuffix           string      `yaml:"encrypted_suffix,omitempty" json:"encrypted_suffix,omitempty"`
 	Version                   string      `yaml:"version" json:"version"`
 }
@@ -152,7 +152,10 @@ func (m *Metadata) ToInternal() (sops.Metadata, error) {
 	if err != nil {
 		return sops.Metadata{}, err
 	}
-	if m.UnencryptedSuffix == "" {
+	if m.UnencryptedSuffix != "" && m.EncryptedSuffix != "" {
+		return sops.Metadata{}, fmt.Errorf("Cannot use both encrypted_suffix and unencrypted_suffix in the same file")
+	}
+	if m.UnencryptedSuffix == "" && m.EncryptedSuffix == "" {
 		m.UnencryptedSuffix = sops.DefaultUnencryptedSuffix
 	}
 	return sops.Metadata{


### PR DESCRIPTION
Answers issue #81.

I've also found the need for encrypted-suffix where we have only a few secrets in a rather large yaml file.

I have run both `make test` and `make functional-tests` and they pass.

