### PR TITLE
Refactor Store interface to reflect operations SOPS performs

### DIFF
--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -76,24 +76,13 @@ func EncryptTree(opts EncryptTreeOpts) error {
 }
 
 // LoadEncryptedFile loads an encrypted SOPS file, returning a SOPS tree
-func LoadEncryptedFile(inputStore sops.Store, inputPath string) (*sops.Tree, error) {
+func LoadEncryptedFile(loader sops.EncryptedFileLoader, inputPath string) (*sops.Tree, error) {
 	fileBytes, err := ioutil.ReadFile(inputPath)
 	if err != nil {
 		return nil, NewExitError(fmt.Sprintf("Error reading file: %s", err), codes.CouldNotReadInputFile)
 	}
-	metadata, err := inputStore.UnmarshalMetadata(fileBytes)
-	if err != nil {
-		return nil, NewExitError(fmt.Sprintf("Error loading file metadata: %s", err), codes.CouldNotReadInputFile)
-	}
-	branch, err := inputStore.Unmarshal(fileBytes)
-	if err != nil {
-		return nil, NewExitError(fmt.Sprintf("Error loading file: %s", err), codes.CouldNotReadInputFile)
-	}
-	tree := sops.Tree{
-		Branch:   branch,
-		Metadata: metadata,
-	}
-	return &tree, nil
+	tree, err := loader.LoadEncryptedFile(fileBytes)
+	return &tree, err
 }
 
 func NewExitError(i interface{}, exitCode int) *cli.ExitError {

--- a/cmd/sops/decrypt.go
+++ b/cmd/sops/decrypt.go
@@ -38,7 +38,7 @@ func decrypt(opts decryptOpts) (decryptedFile []byte, err error) {
 	if len(opts.Extract) > 0 {
 		return extract(tree, opts.Extract, opts.OutputStore)
 	}
-	decryptedFile, err = opts.OutputStore.Marshal(tree.Branch)
+	decryptedFile, err = opts.OutputStore.EmitPlainFile(tree.Branch)
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Error dumping file: %s", err), codes.ErrorDumpingTree)
 	}
@@ -52,7 +52,7 @@ func extract(tree *sops.Tree, path []interface{}, outputStore sops.Store) (outpu
 	}
 	if newBranch, ok := v.(sops.TreeBranch); ok {
 		tree.Branch = newBranch
-		decrypted, err := outputStore.Marshal(tree.Branch)
+		decrypted, err := outputStore.EmitPlainFile(tree.Branch)
 		if err != nil {
 			return nil, common.NewExitError(fmt.Sprintf("Error dumping file: %s", err), codes.ErrorDumpingTree)
 		}
@@ -60,7 +60,7 @@ func extract(tree *sops.Tree, path []interface{}, outputStore sops.Store) (outpu
 	} else if str, ok := v.(string); ok {
 		return []byte(str), nil
 	}
-	bytes, err := outputStore.MarshalValue(v)
+	bytes, err := outputStore.EmitValue(v)
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Error dumping tree: %s", err), codes.ErrorDumpingTree)
 	}

--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -83,13 +83,13 @@ func editExample(opts editExampleOpts) ([]byte, error) {
 		fileBytes = []byte(exampleTree[0].Value.(string))
 	} else {
 		var err error
-		fileBytes, err = opts.InputStore.Marshal(exampleTree)
+		fileBytes, err = opts.InputStore.EmitPlainFile(exampleTree)
 		if err != nil {
 			return nil, err
 		}
 	}
 	var tree sops.Tree
-	branch, err := opts.InputStore.Unmarshal(fileBytes)
+	branch, err := opts.InputStore.LoadPlainFile(fileBytes)
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Error unmarshalling file: %s", err), codes.CouldNotReadInputFile)
 	}
@@ -143,9 +143,9 @@ func editTree(opts editOpts, tree *sops.Tree, dataKey []byte) ([]byte, error) {
 	// Write to temporary file
 	var out []byte
 	if opts.ShowMasterKeys {
-		out, err = opts.OutputStore.MarshalWithMetadata(tree.Branch, tree.Metadata)
+		out, err = opts.OutputStore.EmitEncryptedFile(*tree)
 	} else {
-		out, err = opts.OutputStore.Marshal(tree.Branch)
+		out, err = opts.OutputStore.EmitPlainFile(tree.Branch)
 	}
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Could not marshal tree: %s", err), codes.ErrorDumpingTree)
@@ -178,7 +178,7 @@ func editTree(opts editOpts, tree *sops.Tree, dataKey []byte) ([]byte, error) {
 	}
 
 	// Output the file
-	encryptedFile, err := opts.OutputStore.MarshalWithMetadata(tree.Branch, tree.Metadata)
+	encryptedFile, err := opts.OutputStore.EmitEncryptedFile(*tree)
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Could not marshal tree: %s", err), codes.ErrorDumpingTree)
 	}
@@ -202,7 +202,7 @@ func runEditorUntilOk(opts runEditorUntilOkOpts) error {
 		if err != nil {
 			return common.NewExitError(fmt.Sprintf("Could not read edited file: %s", err), codes.CouldNotReadInputFile)
 		}
-		newBranch, err := opts.InputStore.Unmarshal(edited)
+		newBranch, err := opts.InputStore.LoadPlainFile(edited)
 		if err != nil {
 			log.WithField(
 				"error",
@@ -214,7 +214,9 @@ func runEditorUntilOk(opts runEditorUntilOkOpts) error {
 			continue
 		}
 		if opts.ShowMasterKeys {
-			metadata, err := opts.InputStore.UnmarshalMetadata(edited)
+			// The file is not actually encrypted, but it contains SOPS
+			// metadata
+			t, err := opts.InputStore.LoadEncryptedFile(edited)
 			if err != nil {
 				log.WithField(
 					"error",
@@ -224,7 +226,9 @@ func runEditorUntilOk(opts runEditorUntilOkOpts) error {
 				bufio.NewReader(os.Stdin).ReadByte()
 				continue
 			}
-			opts.Tree.Metadata = metadata
+			// Replace the whole tree, because otherwise newBranch would
+			// contain the SOPS metadata
+			opts.Tree = &t
 		}
 		opts.Tree.Branch = newBranch
 		needVersionUpdated, err := AIsNewerThanB(version, opts.Tree.Metadata.Version)

--- a/cmd/sops/encrypt.go
+++ b/cmd/sops/encrypt.go
@@ -30,7 +30,7 @@ func encrypt(opts encryptOpts) (encryptedFile []byte, err error) {
 		return nil, common.NewExitError(fmt.Sprintf("Error reading file: %s", err), codes.CouldNotReadInputFile)
 	}
 	var tree sops.Tree
-	branch, err := opts.InputStore.Unmarshal(fileBytes)
+	branch, err := opts.InputStore.LoadPlainFile(fileBytes)
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Error unmarshalling file: %s", err), codes.CouldNotReadInputFile)
 	}
@@ -57,7 +57,7 @@ func encrypt(opts encryptOpts) (encryptedFile []byte, err error) {
 		return nil, err
 	}
 
-	encryptedFile, err = opts.OutputStore.MarshalWithMetadata(tree.Branch, tree.Metadata)
+	encryptedFile, err = opts.OutputStore.EmitEncryptedFile(tree)
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Could not marshal tree: %s", err), codes.ErrorDumpingTree)
 	}

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -753,7 +753,7 @@ func jsonValueToTreeInsertableValue(jsonValue string) (interface{}, error) {
 	kind := reflect.ValueOf(valueToInsert).Kind()
 	if kind == reflect.Map || kind == reflect.Slice {
 		var err error
-		valueToInsert, err = (&json.Store{}).Unmarshal([]byte(jsonValue))
+		valueToInsert, err = (&json.Store{}).LoadPlainFile([]byte(jsonValue))
 		if err != nil {
 			return nil, common.NewExitError("Invalid --set value format", codes.ErrorInvalidSetFormat)
 		}

--- a/cmd/sops/rotate.go
+++ b/cmd/sops/rotate.go
@@ -65,7 +65,7 @@ func rotate(opts rotateOpts) ([]byte, error) {
 		return nil, err
 	}
 
-	encryptedFile, err := opts.OutputStore.MarshalWithMetadata(tree.Branch, tree.Metadata)
+	encryptedFile, err := opts.OutputStore.EmitEncryptedFile(*tree)
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Could not marshal tree: %s", err), codes.ErrorDumpingTree)
 	}

--- a/cmd/sops/set.go
+++ b/cmd/sops/set.go
@@ -49,7 +49,7 @@ func set(opts setOpts) ([]byte, error) {
 		return nil, err
 	}
 
-	encryptedFile, err := opts.OutputStore.MarshalWithMetadata(tree.Branch, tree.Metadata)
+	encryptedFile, err := opts.OutputStore.EmitEncryptedFile(*tree)
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Could not marshal tree: %s", err), codes.ErrorDumpingTree)
 	}

--- a/cmd/sops/subcommand/groups/add.go
+++ b/cmd/sops/subcommand/groups/add.go
@@ -35,7 +35,7 @@ func Add(opts AddOpts) error {
 		tree.Metadata.ShamirThreshold = opts.GroupThreshold
 	}
 	tree.Metadata.UpdateMasterKeysWithKeyServices(dataKey, opts.KeyServices)
-	output, err := opts.OutputStore.MarshalWithMetadata(tree.Branch, tree.Metadata)
+	output, err := opts.OutputStore.EmitEncryptedFile(*tree)
 	if err != nil {
 		return err
 	}

--- a/cmd/sops/subcommand/groups/delete.go
+++ b/cmd/sops/subcommand/groups/delete.go
@@ -44,7 +44,7 @@ func Delete(opts DeleteOpts) error {
 	}
 
 	tree.Metadata.UpdateMasterKeysWithKeyServices(dataKey, opts.KeyServices)
-	output, err := opts.OutputStore.MarshalWithMetadata(tree.Branch, tree.Metadata)
+	output, err := opts.OutputStore.EmitEncryptedFile(*tree)
 	if err != nil {
 		return err
 	}

--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -99,7 +99,7 @@ func updateFile(opts Opts) error {
 	if len(errs) > 0 {
 		return fmt.Errorf("error updating one or more master keys: %s", errs)
 	}
-	output, err := store.MarshalWithMetadata(tree.Branch, tree.Metadata)
+	output, err := store.EmitEncryptedFile(*tree)
 	if err != nil {
 		return fmt.Errorf("error marshaling tree: %s", err)
 	}

--- a/sops.go
+++ b/sops.go
@@ -430,13 +430,44 @@ type Metadata struct {
 // KeyGroup is a slice of SOPS MasterKeys that all encrypt the same part of the data key
 type KeyGroup []keys.MasterKey
 
-// Store provides a way to load and save the sops tree along with metadata
+// EncryptedFileLoader is the interface for loading of encrypted files. It provides a
+// way to load encrypted SOPS files into the internal SOPS representation. Because it
+// loads encrypted files, the returned data structure already contains all SOPS
+// metadata.
+type EncryptedFileLoader interface {
+	LoadEncryptedFile(in []byte) (Tree, error)
+}
+
+// PlainFileLoader is the interface for loading of plain text files. It provides a
+// way to load unencrypted files into SOPS. Because the files it loads are
+// unencrypted, the returned data structure does not contain any metadata.
+type PlainFileLoader interface {
+	LoadPlainFile(in []byte) (TreeBranch, error)
+}
+
+// EncryptedFileEmitter is the interface for emitting encrypting files. It provides a
+// way to emit encrypted files from the internal SOPS representation.
+type EncryptedFileEmitter interface {
+	EmitEncryptedFile(Tree) ([]byte, error)
+}
+
+// PlainFileEmitter is the interface for emitting plain text files. It provides a way
+// to emit plain text files from the internal SOPS representation so that they can be
+// shown
+type PlainFileEmitter interface {
+	EmitPlainFile(TreeBranch) ([]byte, error)
+}
+
+type ValueEmitter interface {
+	EmitValue(interface{}) ([]byte, error)
+}
+
 type Store interface {
-	Unmarshal(in []byte) (TreeBranch, error)
-	UnmarshalMetadata(in []byte) (Metadata, error)
-	Marshal(TreeBranch) ([]byte, error)
-	MarshalWithMetadata(TreeBranch, Metadata) ([]byte, error)
-	MarshalValue(interface{}) ([]byte, error)
+	EncryptedFileLoader
+	PlainFileLoader
+	EncryptedFileEmitter
+	PlainFileEmitter
+	ValueEmitter
 }
 
 // MasterKeyCount returns the number of master keys available

--- a/stores/json/store_test.go
+++ b/stores/json/store_test.go
@@ -247,13 +247,15 @@ func TestEncodeJSONArrayOfObjects(t *testing.T) {
 		2
 	]
 }`
-	out, err := Store{}.Marshal(branch)
+	store := Store{}
+	out, err := store.EmitPlainFile(branch)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, string(out))
 }
 
 func TestUnmarshalMetadataFromNonSOPSFile(t *testing.T) {
 	data := []byte(`{"hello": 2}`)
-	_, err := Store{}.UnmarshalMetadata(data)
+	store := Store{}
+	_, err := store.LoadEncryptedFile(data)
 	assert.Equal(t, sops.MetadataNotFound, err)
 }

--- a/stores/json/store_test.go
+++ b/stores/json/store_test.go
@@ -259,3 +259,13 @@ func TestUnmarshalMetadataFromNonSOPSFile(t *testing.T) {
 	_, err := store.LoadEncryptedFile(data)
 	assert.Equal(t, sops.MetadataNotFound, err)
 }
+
+func TestLoadJSONFormattedBinaryFile(t *testing.T) {
+	// This is JSON data, but we want SOPS to interpret it as binary,
+	// e.g. because the --input-type binary flag was provided.
+	data := []byte(`{"hello": 2}`)
+	store := BinaryStore{}
+	branch, err := store.LoadPlainFile(data)
+	assert.Nil(t, err)
+	assert.Equal(t, "data", branch[0].Key)
+}

--- a/stores/yaml/store_test.go
+++ b/stores/yaml/store_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestUnmarshalMetadataFromNonSOPSFile(t *testing.T) {
 	data := []byte(`hello: 2`)
-	_, err := (&Store{}).UnmarshalMetadata(data)
+	_, err := (&Store{}).LoadEncryptedFile(data)
 	assert.Equal(t, sops.MetadataNotFound, err)
 }


### PR DESCRIPTION
Previously the Store interface tried to mimic the Marshaler and Unmarshaler
interfaces. This was a mistake, as it meant Stores had no idea whether the files they
were loading were encrypted or not.

Sort-of-fixes #334, but another bugfix is required to solve that issue "the right way".