### PR TITLE
Fix double encryption prevention

### DIFF
--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -385,4 +385,28 @@ b: ba"#
         assert_eq!(output.stdout, b"multi\nline");
     }
 
+
+    #[test]
+    fn roundtrip_binary() {
+        let data = b"\"\"{}this_is_binary_data";
+        let file_path = prepare_temp_file("test.binary", data);
+        let output = Command::new(SOPS_BINARY_PATH)
+            .arg("-i")
+            .arg("-e")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops");
+        assert!(output.status.success(),
+                "SOPS failed to encrypt a binary file");
+        let output = Command::new(SOPS_BINARY_PATH)
+            .arg("-d")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops");
+        assert!(output.status
+                    .success(),
+                "SOPS failed to decrypt a binary file");
+        assert_eq!(output.stdout, data);
+    }
+
 }


### PR DESCRIPTION
The `ensureNoMetadata` function was incorrectly implemented and called
LoadEncryptedFile on the InputStore and checked whether the returned error was
MetadataNotFound or not. In the case where loading the input file as an encrypted
file would fail (e.g. due to syntax errors), it would incorrectly report the file as
having a "sops" branch. When using the binary mode, it would try to load the file as
an encrypted binary file (which is expected to be JSON), which would fail, thus
triggering this error.

Includes a functional test that would have detected this.