### PR TITLE
Explicitly enabled cgo within Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.8
 COPY . /go/src/go.mozilla.org/sops
 WORKDIR /go/src/go.mozilla.org/sops
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /bin/sops ./cmd/sops
+RUN CGO_ENALBED=1 go build -a -o /bin/sops ./cmd/sops
 RUN apt-get update
 RUN apt-get install -y vim python-pip emacs
 RUN pip install awscli


### PR DESCRIPTION
Currently getting a `user: Current not implemented on linux/amd64` error from https://github.com/mozilla/sops/blob/master/audit/audit.go#L103 within a `mozilla/sop` docker container that has an `/etc/sops/audit.yaml` file.

Per https://github.com/golang/go/issues/14625 - this is caused by disabling `cgo`.

As a follow up, we disable `CGO` for our releases, which makes perfect sense, but will have the same problem.