### PR TITLE
[PYTHON] Fix compatibility with ruamel.yaml >= 0.15.52

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 setuptools>=18.8.1
 cryptography>=1.4
 boto3>=1.1.3
-ruamel.yaml>=0.11.7
+ruamel.yaml>=0.11.7,<0.12.0 ; python_version=="2.6"
+ruamel.yaml>=0.11.7 ; python_version>"2.6"
 ordereddict>=1.1
 simplejson>=3.8
 futures>=3.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools>=18.8.1
-cryptography==1.4
+cryptography>=1.4
 boto3>=1.1.3
-ruamel.yaml==0.11.7
+ruamel.yaml>=0.11.7
 ordereddict>=1.1
 simplejson>=3.8
 futures>=3.0.5


### PR DESCRIPTION
ruamel.yaml 0.15.52 changed `CommentedMap` to no longer subclass `OrderedDict` and 0.15.55 changed `CommentedSeq` to no longer subclass `list`, which broke sops's logic for parsing YAML dicts vs lists.

This patch fixes that by checking `collections.abc.MutableMapping` and `collections.abc.MutableSequence` instead.