### PR TITLE
add --encrypted-selector option

### DIFF
--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -39,6 +39,7 @@ type editExampleOpts struct {
 	editOpts
 	UnencryptedSuffix string
 	EncryptedSuffix   string
+	EncryptedSelector string
 	KeyGroups         []sops.KeyGroup
 	GroupThreshold    int
 }
@@ -104,6 +105,7 @@ func editExample(opts editExampleOpts) ([]byte, error) {
 			KeyGroups:         opts.KeyGroups,
 			UnencryptedSuffix: opts.UnencryptedSuffix,
 			EncryptedSuffix:   opts.EncryptedSuffix,
+			EncryptedSelector: opts.EncryptedSelector,
 			Version:           version,
 			ShamirThreshold:   opts.GroupThreshold,
 		},

--- a/cmd/sops/encrypt.go
+++ b/cmd/sops/encrypt.go
@@ -21,6 +21,7 @@ type encryptOpts struct {
 	KeyServices       []keyservice.KeyServiceClient
 	UnencryptedSuffix string
 	EncryptedSuffix   string
+	EncryptedSelector string
 	KeyGroups         []sops.KeyGroup
 	GroupThreshold    int
 }
@@ -75,6 +76,7 @@ func encrypt(opts encryptOpts) (encryptedFile []byte, err error) {
 			KeyGroups:         opts.KeyGroups,
 			UnencryptedSuffix: opts.UnencryptedSuffix,
 			EncryptedSuffix:   opts.EncryptedSuffix,
+			EncryptedSelector:   opts.EncryptedSelector,
 			Version:           version,
 			ShamirThreshold:   opts.GroupThreshold,
 		},

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -429,6 +429,7 @@ func main() {
 
 		unencryptedSuffix := c.String("unencrypted-suffix")
 		encryptedSuffix := c.String("encrypted-suffix")
+		encryptedSelector := c.String("encrypted-selector")
 		conf, err := loadConfig(c, fileName, nil)
 		if err != nil {
 			return toExitError(err)
@@ -440,6 +441,9 @@ func main() {
 			}
 			if encryptedSuffix == "" {
 				encryptedSuffix = conf.EncryptedSuffix
+			}
+			if encryptedSelector == "" {
+				encryptedSelector = conf.EncryptedSelector
 			}
 		}
 		if unencryptedSuffix != "" && encryptedSuffix != "" {
@@ -473,6 +477,7 @@ func main() {
 				Cipher:            aes.NewCipher(),
 				UnencryptedSuffix: unencryptedSuffix,
 				EncryptedSuffix:   encryptedSuffix,
+				EncryptedSelector:   encryptedSelector,
 				KeyServices:       svcs,
 				KeyGroups:         groups,
 				GroupThreshold:    threshold,
@@ -594,6 +599,7 @@ func main() {
 					editOpts:          opts,
 					UnencryptedSuffix: unencryptedSuffix,
 					EncryptedSuffix:   encryptedSuffix,
+					EncryptedSelector: encryptedSelector,
 					KeyGroups:         groups,
 					GroupThreshold:    threshold,
 				})

--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,7 @@ type creationRule struct {
 	ShamirThreshold   int        `yaml:"shamir_threshold"`
 	UnencryptedSuffix string     `yaml:"unencrypted_suffix"`
 	EncryptedSuffix   string     `yaml:"encrypted_suffix"`
+	EncryptedSelector string     `yaml:"encrypted_selector"`
 }
 
 // Load loads a sops config file into a temporary struct
@@ -114,6 +115,7 @@ type Config struct {
 	ShamirThreshold   int
 	UnencryptedSuffix string
 	EncryptedSuffix   string
+	EncryptedSelector   string
 }
 
 func loadForFileFromBytes(confBytes []byte, filePath string, kmsEncryptionContext map[string]*string) (*Config, error) {
@@ -195,6 +197,7 @@ func loadForFileFromBytes(confBytes []byte, filePath string, kmsEncryptionContex
 		ShamirThreshold:   rule.ShamirThreshold,
 		UnencryptedSuffix: rule.UnencryptedSuffix,
 		EncryptedSuffix:   rule.EncryptedSuffix,
+		EncryptedSelector:   rule.EncryptedSelector,
 	}, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,6 +100,7 @@ creation_rules:
     unencrypted_suffix: _unencrypted
   - path_regex: bar?foo$
     encrypted_suffix: _enc
+    encrypted_selector: data.foo
     key_groups:
       - kms:
           - arn: baz
@@ -232,6 +233,12 @@ func TestLoadConfigFileWithEncryptedSuffix(t *testing.T) {
 	conf, err := loadForFileFromBytes(sampleConfigWithSuffixParameters, "barfoo", nil)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "_enc", conf.EncryptedSuffix)
+}
+
+func TestLoadConfigFileWithEncryptedSelector(t *testing.T) {
+	conf, err := loadForFileFromBytes(sampleConfigWithSuffixParameters, "barfoo", nil)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "data.foo", conf.EncryptedSelector)
 }
 
 func TestLoadConfigFileWithInvalidParameters(t *testing.T) {

--- a/sops.go
+++ b/sops.go
@@ -320,9 +320,8 @@ func (tree Tree) Encrypt(key []byte, cipher Cipher) (string, error) {
 		}
 		if tree.Metadata.EncryptedSelector != "" {
 			encrypted = false
-			pathString := strings.Join(path, ".")
-
-			if strings.HasPrefix(pathString, tree.Metadata.EncryptedSelector) {
+			pathString := strings.Join(path, ".") + "."
+			if strings.HasPrefix(pathString, tree.Metadata.EncryptedSelector + ".") {
 				encrypted = true
 			}
 		}
@@ -371,9 +370,8 @@ func (tree Tree) Decrypt(key []byte, cipher Cipher) (string, error) {
 		}
 		if tree.Metadata.EncryptedSelector != "" {
 			encrypted = false
-			pathString := strings.Join(path, ".")
-
-			if strings.HasPrefix(pathString, tree.Metadata.EncryptedSelector) {
+			pathString := strings.Join(path, ".") + "."
+			if strings.HasPrefix(pathString, tree.Metadata.EncryptedSelector + ".") {
 				encrypted = true
 			}
 		}

--- a/sops.go
+++ b/sops.go
@@ -318,6 +318,14 @@ func (tree Tree) Encrypt(key []byte, cipher Cipher) (string, error) {
 				}
 			}
 		}
+		if tree.Metadata.EncryptedSelector != "" {
+			encrypted = false
+			pathString := strings.Join(path, ".")
+
+			if strings.HasPrefix(pathString, tree.Metadata.EncryptedSelector) {
+				encrypted = true
+			}
+		}
 		if encrypted {
 			var err error
 			pathString := strings.Join(path, ":") + ":"
@@ -359,6 +367,14 @@ func (tree Tree) Decrypt(key []byte, cipher Cipher) (string, error) {
 					encrypted = true
 					break
 				}
+			}
+		}
+		if tree.Metadata.EncryptedSelector != "" {
+			encrypted = false
+			pathString := strings.Join(path, ".")
+
+			if strings.HasPrefix(pathString, tree.Metadata.EncryptedSelector) {
+				encrypted = true
 			}
 		}
 		var v interface{}
@@ -426,6 +442,7 @@ type Metadata struct {
 	LastModified              time.Time
 	UnencryptedSuffix         string
 	EncryptedSuffix           string
+	EncryptedSelector         string
 	MessageAuthenticationCode string
 	Version                   string
 	KeyGroups                 []KeyGroup

--- a/sops_test.go
+++ b/sops_test.go
@@ -133,6 +133,58 @@ func TestEncryptedSuffix(t *testing.T) {
 	}
 }
 
+
+func TestEncryptedSelector(t *testing.T) {
+	branch := TreeBranch{
+		TreeItem{
+			Key:   "foo_encrypted",
+			Value: "bar",
+		},
+		TreeItem{
+			Key: "bar",
+			Value: TreeBranch{
+				TreeItem{
+					Key:   "foo",
+					Value: "bar",
+				},
+			},
+		},
+	}
+	tree := Tree{Branch: branch, Metadata: Metadata{EncryptedSelector: "bar.foo"}}
+	expected := TreeBranch{
+		TreeItem{
+			Key:   "foo_encrypted",
+			Value: "bar",
+		},
+		TreeItem{
+			Key: "bar",
+			Value: TreeBranch{
+				TreeItem{
+					Key:   "foo",
+					Value: "rab",
+				},
+			},
+		},
+	}
+	cipher := reverseCipher{}
+	_, err := tree.Encrypt(bytes.Repeat([]byte("f"), 32), cipher)
+	if err != nil {
+		t.Errorf("Encrypting the tree failed: %s", err)
+	}
+	if !reflect.DeepEqual(tree.Branch, expected) {
+		t.Errorf("Trees don't match: \ngot \t\t%+v,\n expected \t\t%+v", tree.Branch, expected)
+	}
+	_, err = tree.Decrypt(bytes.Repeat([]byte("f"), 32), cipher)
+	if err != nil {
+		t.Errorf("Decrypting the tree failed: %s", err)
+	}
+	expected[1].Value.(TreeBranch)[0].Value = "bar"
+	if !reflect.DeepEqual(tree.Branch, expected) {
+		t.Errorf("Trees don't match: \ngot\t\t\t%+v,\nexpected\t\t%+v", tree.Branch, expected)
+	}
+}
+
+
 type MockCipher struct{}
 
 func (m MockCipher) Encrypt(value interface{}, key []byte, path string) (string, error) {

--- a/sops_test.go
+++ b/sops_test.go
@@ -147,6 +147,10 @@ func TestEncryptedSelector(t *testing.T) {
 					Key:   "foo",
 					Value: "bar",
 				},
+				TreeItem{
+					Key:   "foo2",
+					Value: "bar",
+				},
 			},
 		},
 	}
@@ -162,6 +166,10 @@ func TestEncryptedSelector(t *testing.T) {
 				TreeItem{
 					Key:   "foo",
 					Value: "rab",
+				},
+				TreeItem{
+					Key:   "foo2",
+					Value: "bar",
 				},
 			},
 		},

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -45,6 +45,7 @@ type Metadata struct {
 	PGPKeys                   []pgpkey    `yaml:"pgp" json:"pgp"`
 	UnencryptedSuffix         string      `yaml:"unencrypted_suffix,omitempty" json:"unencrypted_suffix,omitempty"`
 	EncryptedSuffix           string      `yaml:"encrypted_suffix,omitempty" json:"encrypted_suffix,omitempty"`
+	EncryptedSelector           string      `yaml:"encrypted_selector,omitempty" json:"encrypted_selector,omitempty"`
 	Version                   string      `yaml:"version" json:"version"`
 }
 
@@ -89,6 +90,7 @@ func MetadataFromInternal(sopsMetadata sops.Metadata) Metadata {
 	m.LastModified = sopsMetadata.LastModified.Format(time.RFC3339)
 	m.UnencryptedSuffix = sopsMetadata.UnencryptedSuffix
 	m.EncryptedSuffix = sopsMetadata.EncryptedSuffix
+	m.EncryptedSelector = sopsMetadata.EncryptedSelector
 	m.MessageAuthenticationCode = sopsMetadata.MessageAuthenticationCode
 	m.Version = sopsMetadata.Version
 	m.ShamirThreshold = sopsMetadata.ShamirThreshold
@@ -194,6 +196,7 @@ func (m *Metadata) ToInternal() (sops.Metadata, error) {
 		MessageAuthenticationCode: m.MessageAuthenticationCode,
 		UnencryptedSuffix:         m.UnencryptedSuffix,
 		EncryptedSuffix:           m.EncryptedSuffix,
+		EncryptedSelector:           m.EncryptedSelector,
 		LastModified:              lastModified,
 	}, nil
 }


### PR DESCRIPTION
per #368, sometimes we need to pick only a subtree to encrypt (eg. Kubernetes secret). then it should be able to encrypt Kubernetes secret just like https://github.com/shyiko/kubesec 