### PR TITLE
Use $HOME instead ~ to find the gnupg directory.

### DIFF
--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -246,7 +246,7 @@ func (key *MasterKey) gpgHome() string {
 	if dir == "" {
 		usr, err := user.Current()
 		if err != nil {
-			return "~/.gnupg"
+			return path.Join(os.Getenv("HOME"), "/.gnupg")
 		}
 		return path.Join(usr.HomeDir, ".gnupg")
 	}


### PR DESCRIPTION
Fixes #397 

If `HOME` is undefined `gpgHome()` will return `/.gnupg`. gpg has the same behavior.

```
bash-4.2$ env
HOSTNAME=088550c83cf1
TERM=xterm
OLDPWD=/
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/
SHLVL=1
HOME=/
_=/usr/bin/env
bash-4.2$ gpg --import /work/a
gpg: Fatal: can't create directory `//.gnupg': Permission denied
```