### PR TITLE
[PYTHON] Fix --extract on Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ functional-tests-once:
 	fi;
 	echo "Testing --extract"
 	python sops/__init__.py -d --extract '["firstName"]' example.json
-	[ $$(python sops/__init__.py -d --extract '["firstName"]' example.json) == $$(python sops/__init__.py -d example.json | grep firstName | cut -d '"' -f 4) ]
+	[ $$(python sops/__init__.py -d --extract '["firstName"]' example.json) = $$(python sops/__init__.py -d example.json | grep firstName | cut -d '"' -f 4) ]
 
 pypi:
 	$(PYTHON) setup.py sdist check upload --sign

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ functional-tests-once:
 	else \
 		echo "Binary file roundtrip succeeded"; \
 	fi;
+	echo "Testing --extract"
+	python sops/__init__.py -d --extract '["firstName"]' example.json
+	[ $$(python sops/__init__.py -d --extract '["firstName"]' example.json) == $$(python sops/__init__.py -d example.json | grep firstName | cut -d '"' -f 4) ]
 
 pypi:
 	$(PYTHON) setup.py sdist check upload --sign

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 setuptools>=18.8.1
+# pycparser is a transitive dependency of cryptography. 2.18 is the last
+# release with Python 2.6 support
+pycparser==2.18 ; python_version=="2.6"
 cryptography>=1.4
 boto3>=1.1.3
 ruamel.yaml>=0.11.7,<0.12.0 ; python_version=="2.6"

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
         'ruamel.yaml>=0.11.7,<0.12.0 ; python_version=="2.6"',
         'ruamel.yaml>=0.11.7 ; python_version>"2.6"',
         'boto3>=1.1.3',
+        # pycparser is a transitive dependency of cryptography. 2.18 is the
+        # last release with Python 2.6 support
+        'pycparser==2.18 ; python_version=="2.6"',
         'cryptography>=1.4',
         'setuptools>=18.8.1',
         'ordereddict>=1.1',

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -894,11 +894,11 @@ def decrypt(value, key, aad=b'', stash=None, digest=None, unencrypted=False):
             digest.update(bvalue)
         return value
 
-    valre = b'^ENC\[AES256_GCM,data:(.+),iv:(.+),tag:(.+)'
+    valre = b'^ENC\[AES256_GCM,data:(.+),iv:(.+),tag:(.+)'  # noqa: W605
     # extract fields using a regex
     if A_is_newer_than_B(INPUT_VERSION, '0.8'):
         valre += b',type:(.+)'
-    valre += b'\]'
+    valre += b'\]'  # noqa: W605
     res = re.match(valre, value.encode('utf-8'))
     # if the value isn't in encrypted form, return it as is
     if res is None:
@@ -1422,7 +1422,7 @@ def tree_path_comp(comp, path):
     comp = comp[0:len(comp)-1]
     comp = comp.replace('"', '', 2)
     comp = comp.replace("'", "", 2)
-    if re.search(b'^\d+$', comp.encode('utf-8')):
+    if re.search(b'^\d+$', comp.encode('utf-8')):  # noqa: W605
         return int(comp)
     else:
         return comp

--- a/sops/__init__.py
+++ b/sops/__init__.py
@@ -46,6 +46,8 @@ except ImportError:
 if sys.version_info[0] == 3:
     raw_input = input
 
+PY2 = sys.version_info[0] == 2
+
 VERSION = '1.17'
 
 DESC = """
@@ -1028,8 +1030,7 @@ def encrypt(value, key, aad=b'', stash=None, digest=None, unencrypted=False):
     # save the original type
     # the order in which we do this matters. For example, a bool
     # is also an int, but an int isn't a bool, so we test for bool first
-    if isinstance(value, str) or \
-       (sys.version_info[0] == 2 and isinstance(value, unicode)):  # noqa
+    if isinstance(value, str) or (PY2 and isinstance(value, unicode)):  # noqa
         valtype = 'str'
     elif isinstance(value, bool):
         valtype = 'bool'
@@ -1318,7 +1319,10 @@ def write_file(tree, path=None, filetype=None):
         and not isinstance(tree, MutableSequence)
     ):
         if path == 'stdout':
-            sys.stdout.write(tree.encode('utf-8'))
+            if PY2:
+                sys.stdout.write(tree.encode('utf-8'))
+            else:
+                sys.stdout.buffer.write(tree.encode('utf-8'))
         else:
             # Write the entire tree to file descriptor
             fd.write(tree.encode('utf-8'))


### PR DESCRIPTION
Previously, `--extract` would fail on Python 3:

```
Traceback (most recent call last):
  File "/Users/andy/.virtualenvs/sops-py3/bin/sops", line 11, in <module>
    load_entry_point('sops', 'console_scripts', 'sops')()
  File "/Users/andy/forks/sops/sops/__init__.py", line 278, in main
    write_file(tree, path=dest, filetype=otype)
  File "/Users/andy/forks/sops/sops/__init__.py", line 1321, in write_file
    sys.stdout.write(tree.encode('utf-8'))
TypeError: write() argument must be str, not bytes
```