### PR TITLE
Add comment support to dotenv store

### DIFF
--- a/stores/dotenv/store_test.go
+++ b/stores/dotenv/store_test.go
@@ -11,6 +11,7 @@ import (
 var PLAIN = []byte(strings.TrimLeft(`
 VAR1=val1
 VAR2=val2
+#comment
 VAR3_unencrypted=val3
 `, "\n"))
 
@@ -22,6 +23,10 @@ var BRANCH = sops.TreeBranch{
 	sops.TreeItem{
 		Key:   "VAR2",
 		Value: "val2",
+	},
+	sops.TreeItem{
+		Key: sops.Comment{"comment"},
+		Value: nil,
 	},
 	sops.TreeItem{
 		Key:   "VAR3_unencrypted",


### PR DESCRIPTION
It seems most (all?) dotenv implementations support using `#` for comments, so let's do that.