### PR TITLE
Consolidate example trees

### DIFF
--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -17,6 +17,16 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
+type ExampleFileEmitter interface {
+	EmitExample() []byte
+}
+
+type Store interface {
+	sops.Store
+	ExampleFileEmitter
+}
+
+
 // DecryptTreeOpts are the options needed to decrypt a tree
 type DecryptTreeOpts struct {
 	// Tree is the tree to be decrypted
@@ -114,7 +124,7 @@ func IsIniFile(path string) bool {
 	return strings.HasSuffix(path, ".ini")
 }
 
-func DefaultStoreForPath(path string) sops.Store {
+func DefaultStoreForPath(path string) Store {
 	if IsYAMLFile(path) {
 		return &yaml.Store{}
 	} else if IsJSONFile(path) {

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -691,7 +691,7 @@ func keyservices(c *cli.Context) (svcs []keyservice.KeyServiceClient) {
 	return
 }
 
-func inputStore(context *cli.Context, path string) sops.Store {
+func inputStore(context *cli.Context, path string) common.Store {
 	switch context.String("input-type") {
 	case "yaml":
 		return &yamlstores.Store{}
@@ -708,7 +708,7 @@ func inputStore(context *cli.Context, path string) sops.Store {
 	}
 }
 
-func outputStore(context *cli.Context, path string) sops.Store {
+func outputStore(context *cli.Context, path string) common.Store {
 	switch context.String("output-type") {
 	case "yaml":
 		return &yamlstores.Store{}

--- a/sops.go
+++ b/sops.go
@@ -490,6 +490,7 @@ type ValueEmitter interface {
 	EmitValue(interface{}) ([]byte, error)
 }
 
+// Store is used to interact with files, both encrypted and unencrypted.
 type Store interface {
 	EncryptedFileLoader
 	PlainFileLoader

--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -107,6 +107,14 @@ func (Store) EmitValue(v interface{}) ([]byte, error) {
 	return nil, fmt.Errorf("the dotenv store only supports emitting strings, got %T", v)
 }
 
+func (store *Store) EmitExample() []byte {
+	bytes, err := store.EmitPlainFile(stores.ExampleFlatTree.Branches)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
+}
+
 func metadataToMap(md stores.Metadata) (map[string]interface{}, error) {
 	var mdMap map[string]interface{}
 	inrec, err := json.Marshal(md)

--- a/stores/ini/store.go
+++ b/stores/ini/store.go
@@ -14,30 +14,6 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-var ExampleTree = sops.Tree{
-	Branches: sops.TreeBranches{
-		sops.TreeBranch{
-			sops.TreeItem{
-				Key: "Welcome!",
-				Value: sops.TreeBranch{
-					sops.TreeItem{
-						Key:   sops.Comment{Value: "This is an example ini file."},
-						Value: nil,
-					},
-					sops.TreeItem{
-						Key:   "hello",
-						Value: "Welcome to SOPS! Edit this file as you please!",
-					},
-					sops.TreeItem{
-						Key:   "example_key",
-						Value: "example_value",
-					},
-				},
-			},
-		},
-	},
-}
-
 // Store handles storage of ini data.
 type Store struct {
 }
@@ -341,4 +317,12 @@ func (store Store) encodeValue(v interface{}) ([]byte, error) {
 
 func (store *Store) EmitValue(v interface{}) ([]byte, error) {
 	return store.encodeValue(v)
+}
+
+func (store *Store) EmitExample() []byte {
+	bytes, err := store.EmitPlainFile(stores.ExampleSimpleTree.Branches)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
 }

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -52,6 +52,10 @@ func (store BinaryStore) EmitValue(v interface{}) ([]byte, error) {
 	return nil, fmt.Errorf("Binary files are not structured and extracting a single value is not possible")
 }
 
+func (store BinaryStore) EmitExample() []byte {
+	return []byte("Welcome to SOPS! Edit this file as you please!")
+}
+
 func (store Store) sliceFromJSONDecoder(dec *json.Decoder) ([]interface{}, error) {
 	var slice []interface{}
 	for {
@@ -281,4 +285,12 @@ func (store *Store) EmitValue(v interface{}) ([]byte, error) {
 		return nil, err
 	}
 	return store.reindentJSON(s)
+}
+
+func (store *Store) EmitExample() []byte {
+	bytes, err := store.EmitPlainFile(stores.ExampleComplexTree.Branches)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
 }

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -308,3 +308,80 @@ func (pgpKey *pgpkey) toInternal() (*pgp.MasterKey, error) {
 		Fingerprint:  pgpKey.Fingerprint,
 	}, nil
 }
+
+var ExampleComplexTree = sops.Tree{
+	Branches: sops.TreeBranches{
+		sops.TreeBranch{
+			sops.TreeItem{
+				Key:   "hello",
+				Value: `Welcome to SOPS! Edit this file as you please!`,
+			},
+			sops.TreeItem{
+				Key:   "example_key",
+				Value: "example_value",
+			},
+			sops.TreeItem{
+				Key:   sops.Comment{Value: " Example comment"},
+				Value: nil,
+			},
+			sops.TreeItem{
+				Key: "example_array",
+				Value: []interface{}{
+					"example_value1",
+					"example_value2",
+				},
+			},
+			sops.TreeItem{
+				Key:   "example_number",
+				Value: 1234.56789,
+			},
+			sops.TreeItem{
+				Key:   "example_booleans",
+				Value: []interface{}{true, false},
+			},
+		},
+	},
+}
+
+var ExampleSimpleTree = sops.Tree{
+	Branches: sops.TreeBranches{
+		sops.TreeBranch{
+			sops.TreeItem{
+				Key: "Welcome!",
+				Value: sops.TreeBranch{
+					sops.TreeItem{
+						Key:   sops.Comment{Value: " This is an example file."},
+						Value: nil,
+					},
+					sops.TreeItem{
+						Key:   "hello",
+						Value: "Welcome to SOPS! Edit this file as you please!",
+					},
+					sops.TreeItem{
+						Key:   "example_key",
+						Value: "example_value",
+					},
+				},
+			},
+		},
+	},
+}
+
+var ExampleFlatTree = sops.Tree{
+	Branches: sops.TreeBranches{
+		sops.TreeBranch{
+			sops.TreeItem{
+				Key:   sops.Comment{Value: " This is an example file."},
+				Value: nil,
+			},
+			sops.TreeItem{
+				Key:   "hello",
+				Value: "Welcome to SOPS! Edit this file as you please!",
+			},
+			sops.TreeItem{
+				Key:   "example_key",
+				Value: "example_value",
+			},
+		},
+	},
+}

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -186,3 +186,11 @@ func (store *Store) EmitValue(v interface{}) ([]byte, error) {
 	v = store.treeValueToYamlValue(v)
 	return (&yaml.YAMLMarshaler{Indent: 4}).Marshal(v)
 }
+
+func (store *Store) EmitExample() []byte {
+	bytes, err := store.EmitPlainFile(stores.ExampleComplexTree.Branches)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
+}


### PR DESCRIPTION
This also forces `Store` implementations used in the CLI to have an example file.

Adds an example "flat" tree for stores that don't support nested values, and a "simple" tree that doesn't contain fancy values like booleans, arrays, and numbers for stores that only support strings.

Fixes #419 