### PR TITLE
Fixed panic when nano available, but vim is not installed

### DIFF
--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -314,6 +314,6 @@ func lookupAnyEditor(editorNames ...string) (editorPath string, err error) {
 			return editorPath, nil
 		}
 	}
-	err = fmt.Errorf("no editor available: sops supports %s", strings.Join(editorNames, ", "))
+	return "", fmt.Errorf("no editor available: sops attempts to use the editor defined in the EDITOR environment variable, and if that's not set defaults to any of %s, but none of them could be found", strings.Join(editorNames, ", "))
 	return "", err
 }

--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"go.mozilla.org/sops/stores/ini"
 	"io/ioutil"
 	"os"
 
@@ -23,6 +22,7 @@ import (
 	"go.mozilla.org/sops/cmd/sops/codes"
 	"go.mozilla.org/sops/cmd/sops/common"
 	"go.mozilla.org/sops/keyservice"
+	"go.mozilla.org/sops/stores/ini"
 	"go.mozilla.org/sops/stores/json"
 )
 
@@ -287,16 +287,15 @@ func runEditor(path string) error {
 	editor := os.Getenv("EDITOR")
 	var cmd *exec.Cmd
 	if editor == "" {
-		cmd = exec.Command("which", "vim", "nano")
-		out, err := cmd.Output()
+		editor, err := lookupAnyEditor("vim", "nano")
 		if err != nil {
-			panic("Could not find any editors")
+			return err
 		}
-		cmd = exec.Command(strings.Split(string(out), "\n")[0], path)
+		cmd = exec.Command(editor, path)
 	} else {
 		parts, err := shlex.Split(editor)
 		if err != nil {
-			return fmt.Errorf("Invalid $EDITOR: %s", editor)
+			return fmt.Errorf("invalid $EDITOR: %s", editor)
 		}
 		parts = append(parts, path)
 		cmd = exec.Command(parts[0], parts[1:]...)
@@ -306,4 +305,15 @@ func runEditor(path string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func lookupAnyEditor(editorNames ...string) (editorPath string, err error) {
+	for _, editorName := range editorNames {
+		editorPath, err = exec.LookPath(editorName)
+		if err == nil {
+			return editorPath, nil
+		}
+	}
+	err = fmt.Errorf("no editor available: sops supports %s", strings.Join(editorNames, ", "))
+	return "", err
 }

--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -315,5 +315,4 @@ func lookupAnyEditor(editorNames ...string) (editorPath string, err error) {
 		}
 	}
 	return "", fmt.Errorf("no editor available: sops attempts to use the editor defined in the EDITOR environment variable, and if that's not set defaults to any of %s, but none of them could be found", strings.Join(editorNames, ", "))
-	return "", err
 }


### PR DESCRIPTION
Command `which vim nano` returns 1 when only nano editor is installed
The solutions is to lookup several times

Also improved error reporting: the old code violated two rules from [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments): "Don't panic" and "Error Strings"