### PR TITLE
Add vi to known editors

### DIFF
--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -287,7 +287,7 @@ func runEditor(path string) error {
 	editor := os.Getenv("EDITOR")
 	var cmd *exec.Cmd
 	if editor == "" {
-		editor, err := lookupAnyEditor("vim", "nano")
+		editor, err := lookupAnyEditor("vim", "nano", "vi")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
By default on alpine there is just vi (busybox compat).

```
/ # cat /etc/os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.9.0
PRETTY_NAME="Alpine Linux v3.9"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
/ # which vim nano vi
/usr/bin/vi
```