### PR TITLE
Fix KMS encryption context handling

### DIFF
--- a/keyservice/server.go
+++ b/keyservice/server.go
@@ -31,7 +31,8 @@ func (ks *Server) encryptWithPgp(key *PgpKey, plaintext []byte) ([]byte, error) 
 func (ks *Server) encryptWithKms(key *KmsKey, plaintext []byte) ([]byte, error) {
 	ctx := make(map[string]*string)
 	for k, v := range key.Context {
-		ctx[k] = &v
+		value := v // Allocate a new string to prevent the pointer below from referring to only the last iteration value
+		ctx[k] = &value
 	}
 	kmsKey := kms.MasterKey{
 		Arn:               key.Arn,
@@ -80,7 +81,8 @@ func (ks *Server) decryptWithPgp(key *PgpKey, ciphertext []byte) ([]byte, error)
 func (ks *Server) decryptWithKms(key *KmsKey, ciphertext []byte) ([]byte, error) {
 	ctx := make(map[string]*string)
 	for k, v := range key.Context {
-		ctx[k] = &v
+		value := v // Allocate a new string to prevent the pointer below from referring to only the last iteration value
+		ctx[k] = &value
 	}
 	kmsKey := kms.MasterKey{
 		Arn:               key.Arn,

--- a/keyservice/server.go
+++ b/keyservice/server.go
@@ -29,17 +29,7 @@ func (ks *Server) encryptWithPgp(key *PgpKey, plaintext []byte) ([]byte, error) 
 }
 
 func (ks *Server) encryptWithKms(key *KmsKey, plaintext []byte) ([]byte, error) {
-	ctx := make(map[string]*string)
-	for k, v := range key.Context {
-		value := v // Allocate a new string to prevent the pointer below from referring to only the last iteration value
-		ctx[k] = &value
-	}
-	kmsKey := kms.MasterKey{
-		Arn:               key.Arn,
-		Role:              key.Role,
-		EncryptionContext: ctx,
-		AwsProfile:        key.AwsProfile,
-	}
+	kmsKey := kmsKeyToMasterKey(key)
 	err := kmsKey.Encrypt(plaintext)
 	if err != nil {
 		return nil, err
@@ -79,17 +69,7 @@ func (ks *Server) decryptWithPgp(key *PgpKey, ciphertext []byte) ([]byte, error)
 }
 
 func (ks *Server) decryptWithKms(key *KmsKey, ciphertext []byte) ([]byte, error) {
-	ctx := make(map[string]*string)
-	for k, v := range key.Context {
-		value := v // Allocate a new string to prevent the pointer below from referring to only the last iteration value
-		ctx[k] = &value
-	}
-	kmsKey := kms.MasterKey{
-		Arn:               key.Arn,
-		Role:              key.Role,
-		EncryptionContext: ctx,
-		AwsProfile:        key.AwsProfile,
-	}
+	kmsKey := kmsKeyToMasterKey(key)
 	kmsKey.EncryptedKey = string(ciphertext)
 	plaintext, err := kmsKey.Decrypt()
 	return []byte(plaintext), err
@@ -250,4 +230,18 @@ func (ks Server) Decrypt(ctx context.Context,
 		}
 	}
 	return response, nil
+}
+
+func kmsKeyToMasterKey(key *KmsKey) kms.MasterKey {
+	ctx := make(map[string]*string)
+	for k, v := range key.Context {
+		value := v // Allocate a new string to prevent the pointer below from referring to only the last iteration value
+		ctx[k] = &value
+	}
+	return kms.MasterKey{
+		Arn:               key.Arn,
+		Role:              key.Role,
+		EncryptionContext: ctx,
+		AwsProfile:        key.AwsProfile,
+	}
 }

--- a/keyservice/server_test.go
+++ b/keyservice/server_test.go
@@ -1,0 +1,81 @@
+package keyservice
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestKmsKeyToMasterKey(t *testing.T) {
+
+	cases := []struct {
+		description        string
+		expectedArn        string
+		expectedRole       string
+		expectedCtx        map[string]string
+		expectedAwsProfile string
+	}{
+		{
+			description:        "empty context",
+			expectedArn:        "arn:aws:kms:eu-west-1:123456789012:key/d5c90a06-f824-4628-922b-12424571ed4d",
+			expectedRole:       "ExampleRole",
+			expectedCtx:        map[string]string{},
+			expectedAwsProfile: "",
+		},
+		{
+			description:  "context with one key-value pair",
+			expectedArn:  "arn:aws:kms:eu-west-1:123456789012:key/d5c90a06-f824-4628-922b-12424571ed4d",
+			expectedRole: "",
+			expectedCtx: map[string]string{
+				"firstKey": "first value",
+			},
+			expectedAwsProfile: "ExampleProfile",
+		},
+		{
+			description:  "context with three key-value pairs",
+			expectedArn:  "arn:aws:kms:eu-west-1:123456789012:key/d5c90a06-f824-4628-922b-12424571ed4d",
+			expectedRole: "",
+			expectedCtx: map[string]string{
+				"firstKey":  "first value",
+				"secondKey": "second value",
+				"thirdKey":  "third value",
+			},
+			expectedAwsProfile: "",
+		},
+	}
+
+	for _, c := range cases {
+
+		t.Run(c.description, func(t *testing.T) {
+
+			inputCtx := make(map[string]string)
+			for k, v := range c.expectedCtx {
+				inputCtx[k] = v
+			}
+
+			key := &KmsKey{
+				Arn:        c.expectedArn,
+				Role:       c.expectedRole,
+				Context:    inputCtx,
+				AwsProfile: c.expectedAwsProfile,
+			}
+
+			masterKey := kmsKeyToMasterKey(key)
+			foundCtx := masterKey.EncryptionContext
+
+			for k, _ := range c.expectedCtx {
+				require.Containsf(t, foundCtx, k, "Context does not contain expected key '%s'", k)
+			}
+			for k, _ := range foundCtx {
+				require.Containsf(t, c.expectedCtx, k, "Context contains an unexpected key '%s' which cannot be found from expected map", k)
+			}
+			for k, expected := range c.expectedCtx {
+				foundVal := *foundCtx[k]
+				assert.Equalf(t, expected, foundVal, "Context key '%s' value '%s' does not match expected value '%s'", k, foundVal, expected)
+			}
+			assert.Equalf(t, c.expectedArn, masterKey.Arn, "Expected ARN to be '%s', but found '%s'", c.expectedArn, masterKey.Arn)
+			assert.Equalf(t, c.expectedRole, masterKey.Role, "Expected Role to be '%s', but found '%s'", c.expectedRole, masterKey.Role)
+			assert.Equalf(t, c.expectedAwsProfile, masterKey.AwsProfile, "Expected AWS profile to be '%s', but found '%s'", c.expectedAwsProfile, masterKey.AwsProfile)
+		})
+	}
+}


### PR DESCRIPTION
It turns out that sops doesn't send correct KMS encryption context key-value pairs to KMS service during encryption and decryption operations. If an encryption context contains at least two key-value pairs and more than one unique value among the keys' values, sops will incorrectly call KMS API with an encryption context where all correct keys are present, but they all have the same value. This pull request fixes that and adds a regression test for KMS encryption context handling in `keyservice/server.go`, where the bug occurs. 

### Example of the bug
Suppose sops is asked to encrypt a new file with the following encryption context.
```
"first key": "first value"
"second key": "second value"
"third key": "third value"
```
In that case, sops sends to KMS an encryption context where every key has exactly the same value, which is chosen randomly from the values of the actually requested encryption context above. This random choice happens on every invocation of sops KMS encrypt or decrypt command and can lead to sops attempting to encrypt and decrypt with different encryption contexts between successive invocations!
```
"first key": "second value"
"second key": "second value"
"third key": "second value"
```
### Consequences
Due to the nature of the bug, it looks like the data key in every KMS encryption context using sops file has been incorrectly encrypted, provided that the following conditions are fulfilled.
- KMS encryption context is used
- At lest two key-value pairs are provided in the encryption context
- The encryption context's key-value pairs have more than one unique value

**As a result, this pull request's fix will break decryption of any such KMS-backed data keys!** 

#### Workaround suggestion
This pull request only includes the immediate bug fix, but it would be worthwhile for the sops team to consider implementing a compatibility feature that can detect the presence of KMS encryption context configuration that is impacted by this bug. Sops could then prompt the user if sops should be allowed to perform multiple KMS decrypt requests to find out which unique encryption context value was actually used for all context keys when the data key was previously successfully encrypted while the bug was present. It should be possible to detect such KMS encryption context configurations, because the bug only impacts what is sent to the KMS API, meaning that the serialised sops file should still have to the correct encryption context configuration.

