### PR TITLE
Add support for custom GPG key servers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -533,8 +533,9 @@ Example: place the following in your ``~/.bashrc``
 Specify a different GPG key server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, ``sops`` uses the key server ``gpg.mozilla.org`` to retrieve GPG keys.
-To specify a different GPG key server, set the ``SOPS_GPG_KEYSERVER`` environment
+By default, ``sops`` uses the key server ``gpg.mozilla.org`` to retrieve the GPG
+keys that are not present in the local keyring.
+To use a different GPG key server, set the ``SOPS_GPG_KEYSERVER`` environment
 variable.
 
 Example: place the following in your ``~/.bashrc``

--- a/README.rst
+++ b/README.rst
@@ -529,6 +529,21 @@ Example: place the following in your ``~/.bashrc``
 
 	SOPS_GPG_EXEC = 'your_gpg_client_wrapper'
 
+
+Specify a different GPG key server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, ``sops`` uses the key server ``gpg.mozilla.org`` to retrieve GPG keys.
+To specify a different GPG key server, set the ``SOPS_GPG_KEYSERVER`` environment
+variable.
+
+Example: place the following in your ``~/.bashrc``
+
+.. code:: bash
+
+	SOPS_GPG_KEYSERVER = 'gpg.example.com'
+
+
 Key groups
 ~~~~~~~~~~
 

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -96,6 +96,7 @@ func main() {
    the "add-{kms,pgp,gcp-kms,azure-kv}" and "rm-{kms,pgp,gcp-kms,azure-kv}" flags.
 
    To use a different GPG binary than the one in your PATH, set SOPS_GPG_EXEC.
+   To use a GPG key server other than gpg.mozilla.org, set SOPS_GPG_KEYSERVER.
 
    To select a different editor than the default (vim), set EDITOR.
 

--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -99,6 +99,14 @@ func getKeyFromKeyServer(keyserver string, fingerprint string) (openpgp.Entity, 
 	return *ents[0], nil
 }
 
+func gpgKeyServer() string {
+	keyServer := "gpg.mozilla.org"
+	if envKeyServer := os.Getenv("SOPS_GPG_KEYSERVER"); envKeyServer != "" {
+		keyServer = envKeyServer
+	}
+	return keyServer
+}
+
 func (key *MasterKey) getPubKey() (openpgp.Entity, error) {
 	ring, err := key.pubRing()
 	if err == nil {
@@ -108,7 +116,8 @@ func (key *MasterKey) getPubKey() (openpgp.Entity, error) {
 			return entity, nil
 		}
 	}
-	entity, err := getKeyFromKeyServer("gpg.mozilla.org", key.Fingerprint)
+	keyServer := gpgKeyServer()
+	entity, err := getKeyFromKeyServer(keyServer, key.Fingerprint)
 	if err != nil {
 		return openpgp.Entity{},
 			fmt.Errorf("key with fingerprint %s is not available "+


### PR DESCRIPTION
Add support for the SOPS_GPG_KEYSERVER environment variable to
override the default GPG key server (gpg.mozilla.org).