### PR TITLE
Only run kms functional tests within mozilla/sops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
   - source ~/.cargo/env
 
 script:
-  - 'if [ "$TRAVIS_REPO_SLUG" != "mozilla/sop" ]; then make; fi'
-  - 'if [ "$TRAVIS_REPO_SLUG" = "mozilla/sop" ]; then make origin-build; fi'
+  - 'if [ "$TRAVIS_REPO_SLUG" != "mozilla/sops" ]; then make; fi'
+  - 'if [ "$TRAVIS_REPO_SLUG" = "mozilla/sops" ]; then make origin-build; fi'
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
   - source ~/.cargo/env
 
 script:
-  - make
+  - 'if [ "$TRAVIS_REPO_SLUG" != "mozilla/sop" ]; then make; fi'
+  - 'if [ "$TRAVIS_REPO_SLUG" = "mozilla/sop" ]; then make origin-build; fi'
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GO 		:= GO15VENDOREXPERIMENT=1 go
 GOLINT 		:= golint
 
 all: test vet generate install functional-tests
+origin-build: test vet generate install functional-tests-all
 
 install:
 	$(GO) install go.mozilla.org/sops/cmd/sops
@@ -39,6 +40,12 @@ generate: keyservice/keyservice.pb.go
 functional-tests:
 	$(GO) build -o functional-tests/sops go.mozilla.org/sops/cmd/sops
 	cd functional-tests && cargo test
+
+# Ignored tests are ones that require external services (e.g. AWS KMS)
+# 	TODO: Once `--include-ignored` lands in rust stable, switch to that.
+functional-tests-all:
+	$(GO) build -o functional-tests/sops go.mozilla.org/sops/cmd/sops
+	cd functional-tests && cargo test && cargo test -- --ignored
 
 deb-pkg: install
 	rm -rf tmppkg

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -75,14 +75,9 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn encrypt_json_file_kms() {
-	let kms_arn = match env::var(KMS_KEY) {
-	    Ok(val) => val,
-	    _ => "".to_string(),
-	};
-        if kms_arn == "" {
-            return;
-        }
+        let kms_arn = env::var(KMS_KEY).expect("Expected $FUNCTIONAL_TEST_KMS_ARN env var to be set");
 
         let file_path = prepare_temp_file("test_encrypt_kms.json",
                                           b"{
@@ -450,14 +445,9 @@ b: ba"#
     }
 
     #[test]
+    #[ignore]
     fn roundtrip_kms_encryption_context() {
-	let kms_arn = match env::var(KMS_KEY) {
-	    Ok(val) => val,
-	    _ => "".to_string(),
-	};
-        if kms_arn == "" {
-            return;
-        }
+        let kms_arn = env::var(KMS_KEY).expect("Expected $FUNCTIONAL_TEST_KMS_ARN env var to be set");
 
         let file_path = prepare_temp_file("test_roundtrip_kms_encryption_context.json",
                                           b"{


### PR DESCRIPTION
Instead of exiting early, only run the kms tests within the context of
mozilla/sops (and not from forks).