### PR TITLE
Upgrade to golang:1.11 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.11
 
 COPY . /go/src/go.mozilla.org/sops
 WORKDIR /go/src/go.mozilla.org/sops


### PR DESCRIPTION
Cause of our current problems in CircleCI: https://superuser.com/a/1417656

Rather than creating a special fix for debian jessie, seems best to just upgrade to a more recent golang container (which is based off of the newer debian stretch)
