### PR TITLE
use golang 1.12 for building sops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/go.mozilla.org/sops
     docker:
-      - image: circleci/golang:1.8
+      - image: circleci/golang:1.12
     steps:
       - checkout
       - setup_remote_docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.9
+go: 1.12
 go_import_path: go.mozilla.org/sops/
 
 addons:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Mozilla welcomes contributions from everyone. Here are a few guidelines and inst
 
 # Getting started
 
-* Make sure you have Go 1.6 or greater installed. You can find information on how to install Go [here](https://golang.org/dl/)
+* Make sure you have Go 1.12 or greater installed. You can find information on how to install Go [here](https://golang.org/dl/)
 * After following the [Go installation guide](https://golang.org/doc/install), run `go get go.mozilla.org/sops`. This will automatically clone this repository.
 * Switch into sops's directory, which will be in `$GOPATH/src/go.mozilla.org/sops`.
 * Run the tests with `make test`. They should all pass.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 COPY . /go/src/go.mozilla.org/sops
 WORKDIR /go/src/go.mozilla.org/sops

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ For the adventurous, unstable features are available in the `develop` branch, wh
         $ git checkout develop
         $ make install
 
-(requires Go >= 1.8)
+(requires Go >= 1.12)
 
 If you don't have Go installed, set it up with:
 


### PR DESCRIPTION
Golang 1.12 is the latest and should be sufficiently backwards-compatible.