### PR TITLE
Changes to travis config and docs for using develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
   - source ~/.cargo/env
 
 script:
-  - 'if [ "$TRAVIS_REPO_SLUG" != "mozilla/sops" ]; then make; fi'
-  - 'if [ "$TRAVIS_REPO_SLUG" = "mozilla/sops" ]; then make origin-build; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make origin-build; fi'
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,9 @@ Mozilla welcomes contributions from everyone. Here are a few guidelines and inst
 * Add your fork to git's remotes:
   * If you use SSH authentication: `git remote add <your username> git@github.com:<your username>/sops.git`.
   * Otherwise: `git remote add <your username> https://github.com/<your username>/sops.git`.
+* **Switch to the `develop` branch: `git checkout develop`**
 * Make any changes you want to sops, commit them, and push them to your fork.
-* Create a pull request, and a contributor will come by and review your code. They may ask for some changes, and hopefully your contribution will be merged to the `master` branch!
+* **Create a pull request against `develop`**, and a contributor will come by and review your code. They may ask for some changes, and hopefully your contribution will be merged to the `develop` branch!
 
 # Guidelines
 

--- a/README.rst
+++ b/README.rst
@@ -24,11 +24,14 @@ Binaries and packages of the latest stable release are available at `https://git
 
 Development branch
 ~~~~~~~~~~~~~~~~~~
-For the adventurous, unstable features are available in the master branch, which you can install with:
+For the adventurous, unstable features are available in the `develop` branch, which you can install from source:
 
 .. code:: bash
 
 	$ go get -u go.mozilla.org/sops/cmd/sops
+        $ cd $GOPATH/src/go.mozilla.org/sops/
+        $ git checkout develop
+        $ make install
 
 (requires Go >= 1.8)
 
@@ -215,7 +218,7 @@ And decrypt it using::
 	 $ sops --decrypt test.enc.yaml
 
 Encrypting using Azure Key Vault
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Azure Key Vault integration uses service principals to access secrets in
 the vault. The following environment variables are used to authenticate:
 
@@ -826,6 +829,7 @@ formats like ``JSON`` do not. ``sops`` is able to handle both. This means the
 following multi-document will be encrypted as expected:
 
 .. code:: yaml
+
 	---
 	data: foo
 	---


### PR DESCRIPTION
* Fixes integration tests in travis to not run on PR's (they will now
run on merges into `develop` and `master`)
* Change README.rst and CONTRIBUTING.md to reflect the use of `develop`
as the primary development branch