### PR TITLE
pgp/keysource: Check size of key fingerprint

### DIFF
--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -58,6 +58,10 @@ func gpgBinary() string {
 }
 
 func (key *MasterKey) encryptWithGPGBinary(dataKey []byte) error {
+	fingerprint := key.Fingerprint
+	if offset := len(fingerprint) - 16; offset > 0 {
+		fingerprint = fingerprint[offset:]
+	}
 	args := []string{
 		"--no-default-recipient",
 		"--yes",
@@ -66,7 +70,7 @@ func (key *MasterKey) encryptWithGPGBinary(dataKey []byte) error {
 		"-r",
 		key.Fingerprint,
 		"--trusted-key",
-		key.Fingerprint[len(key.Fingerprint)-16:],
+		fingerprint,
 		"--no-encrypt-to",
 	}
 	cmd := exec.Command(gpgBinary(), args...)


### PR DESCRIPTION
Make sure the key fingerprint is longer than 16 characters before
slicing it.

Closes #463