### PR TITLE
Bump to 3.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+3.3.1
+-----
+
+Bug fixes:
+
+* Make sure the pgp key fingerprint is longer than 16 characters before
+  slicing it. (#463)
+* Allow for `--set` value to be a string. (#461)
+
+Project changes:
+
+* Using `develop` as a staging branch to create releases off of. What
+  is in `master` is now the current stable release.
+* Upgrade to using Go 1.12 to build sops
+* Updated all vendored packages
+
 3.3.0
 -----
 

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-const Version = "3.3.0"
+const Version = "3.3.1"
 
 func PrintVersion(c *cli.Context) {
 	out := fmt.Sprintf("%s %s", c.App.Name, c.App.Version)


### PR DESCRIPTION
Changelog and `Version` bump for releasing 3.3.1

Would be good to get the change to using `develop` out.