### PR TITLE
encrypt.go: Fix panic on reading empty file

### DIFF
--- a/cmd/sops/codes/codes.go
+++ b/cmd/sops/codes/codes.go
@@ -28,4 +28,5 @@ const (
 	NoEditorFound                          int = 201
 	FailedToCompareVersions                int = 202
 	FileAlreadyEncrypted                   int = 203
+	FileContentsEmpty                      int = 204
 )

--- a/cmd/sops/encrypt.go
+++ b/cmd/sops/encrypt.go
@@ -63,6 +63,9 @@ func encrypt(opts encryptOpts) (encryptedFile []byte, err error) {
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Error unmarshalling file: %s", err), codes.CouldNotReadInputFile)
 	}
+	if len(branches) == 0 {
+		return nil, common.NewExitError(fmt.Sprintf("Error encrypting empty file"), codes.FileContentsEmpty)
+	}
 	if err := ensureNoMetadata(opts, branches[0]); err != nil {
 		return nil, common.NewExitError(err, codes.FileAlreadyEncrypted)
 	}


### PR DESCRIPTION
Fixes a panic crash when a file is loaded without any contents.
Adds a new error `FileContentsEmpty` in `codes.go`.

Fixes https://github.com/mozilla/sops/issues/483