### PR TITLE
Adding support for azure keyvault in key group config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -170,6 +170,9 @@ func loadForFileFromBytes(confBytes []byte, filePath string, kmsEncryptionContex
 			for _, k := range group.GCPKMS {
 				keyGroup = append(keyGroup, gcpkms.NewMasterKeyFromResourceID(k.ResourceID))
 			}
+			for _, k := range group.AzureKV {
+				keyGroup = append(keyGroup, azkv.NewMasterKey(k.VaultURL, k.Key, k.Version))
+			}
 			groups = append(groups, keyGroup)
 		}
 	} else {


### PR DESCRIPTION
Added support to the key group configuration to support AzureKV. It was added to the keyGroup struct but never used.