### PR TITLE
Add an --exec flag to pass decrypted secrets via environment variables to a child process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -803,8 +803,8 @@ By default ``sops`` just dumps all the output to the standard output. We can use
 ``--output`` flag followed by a filename to save the output to the file specified.
 Beware using both ``--in-place`` and ``--output`` flags will result in an error.
 
-Passing Secrets to a Other Processes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing Secrets to Other Processes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In addition to writing secrets to standard output and to files on disk, ``sops``
 has two commands for passing decrypted secrets to a new process: ``exec-env``
 and ``exec-file``. These commands will place all output into the environment of

--- a/README.rst
+++ b/README.rst
@@ -803,6 +803,104 @@ By default ``sops`` just dumps all the output to the standard output. We can use
 ``--output`` flag followed by a filename to save the output to the file specified.
 Beware using both ``--in-place`` and ``--output`` flags will result in an error.
 
+Passing Secrets to a Other Processes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In addition to writing secrets to standard output and to files on disk, ``sops``
+has two commands for passing decrypted secrets to a new process: ``exec-env``
+and ``exec-file``. These commands will place all output into the environment of
+a child process and into a temporary file, respectively. For example, if a
+program looks for credentials in its environment, ``exec-env`` can be used to
+ensure that the decrypted contents are available only to this process and never
+written to disk.
+
+.. code:: bash
+
+   # print secrets to stdout to confirm values
+   $ sops -d out.json
+   {
+           "database_password": "jf48t9wfw094gf4nhdf023r",
+           "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+           "AWS_SECRET_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+   }
+   
+   # decrypt out.json and run a command
+   # the command prints the environment variable and runs a script that uses it
+   $ sops exec-env out.json 'echo secret: $database_password; ./database-import'
+   secret: jf48t9wfw094gf4nhdf023r
+   
+   # launch a shell with the secrets available in its environment
+   $ sops exec-env out.json 'sh'
+   sh-3.2# echo $database_password
+   jf48t9wfw094gf4nhdf023r
+   
+   # the secret is not accessible anywhere else
+   sh-3.2$ exit
+   $ echo your password: $database_password
+   your password: 
+
+
+If the command you want to run only operates on files, you can use ``exec-file``
+instead. By default ``sops`` will use a FIFO to pass the contents of the
+decrypted file to the new program. Using a FIFO, secrets are only passed in
+memory which has two benefits: the plaintext secrets never touch the disk, and
+the child process can only read the secrets once. In contexts where this won't
+work, such as platforms where FIFOs are not available or secret files need to be
+available to the child process longer term, the ``--no-fifo`` flag can be used
+to instruct ``sops`` to use a traditional temporary file that will get cleaned
+up once the process is finished executing. ``exec-file`` behaves similar to
+``find(1)`` in that ``{}`` is used as a placeholder in the command which will be
+substituted with the temporary file path (whether a FIFO or an actual file).
+
+.. code:: bash
+
+   # operating on the same file as before, but as a file this time
+   $ sops exec-file out.json 'echo your temporary file: {}; cat {}'
+   your temporary file: /tmp/.sops894650499/tmp-file
+   {
+           "database_password": "jf48t9wfw094gf4nhdf023r",
+           "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+           "AWS_SECRET_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+   }
+   
+   # launch a shell with a variable TMPFILE pointing to the temporary file
+   $ sops exec-file --no-fifo out.json 'TMPFILE={} sh'
+   sh-3.2$ echo $TMPFILE
+   /tmp/.sops506055069/tmp-file291138648
+   sh-3.2$ cat $TMPFILE
+   {
+           "database_password": "jf48t9wfw094gf4nhdf023r",
+           "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+           "AWS_SECRET_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+   }
+   sh-3.2$ ./program --config $TMPFILE
+   sh-3.2$ exit
+
+   # try to open the temporary file from earlier
+   $ cat /tmp/.sops506055069/tmp-file291138648
+   cat: /tmp/.sops506055069/tmp-file291138648: No such file or directory
+
+Additionally, both ``exec-env`` and ``exec-file`` support dropping privileges
+before executing the new program via the ``--user <username>`` flag. This is
+particularly useful in cases where the encrypted file is only readable by root,
+but the target program does not need root privileges to function. This flag
+should be used where possible for added security.
+
+.. code:: bash
+
+   # the encrypted file can't be read by the current user
+   $ cat out.json
+   cat: out.json: Permission denied
+   
+   # execute sops as root, decrypt secrets, then drop privileges
+   $ sudo sops exec-env --user nobody out.json 'sh'
+   sh-3.2$ echo $database_password
+   jf48t9wfw094gf4nhdf023r
+
+   # dropped privileges, still can't load the original file
+   sh-3.2$ id
+   uid=4294967294(nobody) gid=4294967294(nobody) groups=4294967294(nobody)
+   sh-3.2$ cat out.json
+   cat: out.json: Permission denied
 
 Using the publish command
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -116,6 +116,10 @@ func main() {
 					Name: "background",
 					Usage: "background the process and don't wait for it to complete",
 				},
+				cli.StringFlag{
+					Name: "user",
+					Usage: "the user to run the command as",
+				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
@@ -143,10 +147,11 @@ func main() {
 					return toExitError(err)
 				}
 
-				exec.Exec(exec.ExecOpts{
+				exec.ExecWithEnv(exec.ExecOpts{
 					Command: command,
 					Plaintext: output,
 					Background: c.Bool("background"),
+					User: c.String("user"),
 				})
 
 				return nil
@@ -164,6 +169,10 @@ func main() {
 				cli.BoolFlag{
 					Name: "no-fifo",
 					Usage: "use a regular file instead of a fifo to temporarily hold the decrypted contents",
+				},
+				cli.StringFlag{
+					Name: "user",
+					Usage: "the user to run the command as",
 				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
@@ -197,6 +206,7 @@ func main() {
 					Plaintext: output,
 					Background: c.Bool("background"),
 					Fifo: !c.Bool("no-fifo"),
+					User: c.String("user"),
 				})
 
 				return nil

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -465,10 +465,10 @@ func main() {
 			Name:  "output",
 			Usage: "Save the output after encryption or decryption to the file specified",
 		},
-        cli.StringFlag{
-            Name: "exec",
-            Usage: "run a program with the decrypted data added its environment. only dotenv is supported.",
-        },
+		cli.StringFlag{
+			Name: "exec",
+			Usage: "run a program with the decrypted data added its environment. only dotenv is supported.",
+		},
 	}, keyserviceFlags...)
 
 	app.Action = func(c *cli.Context) error {

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -161,6 +161,10 @@ func main() {
 					Name: "background",
 					Usage: "background the process and don't wait for it to complete",
 				},
+				cli.BoolFlag{
+					Name: "no-fifo",
+					Usage: "use a regular file instead of a fifo to temporarily hold the decrypted contents",
+				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
@@ -192,6 +196,7 @@ func main() {
 					Command: command,
 					Plaintext: output,
 					Background: c.Bool("background"),
+					Fifo: !c.Bool("no-fifo"),
 				})
 
 				return nil

--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -1,0 +1,93 @@
+package exec
+
+import (
+	"bytes"
+	"log"
+	"io/ioutil"
+	"syscall"
+	"path/filepath"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func init() {
+}
+
+type ExecOpts struct {
+	Command string
+	Plaintext []byte
+	Background bool
+}
+
+func WritePipe(pipe string, contents []byte) {
+	handle, err := os.OpenFile(pipe, os.O_WRONLY, 0600)
+
+	if err != nil {
+		os.Remove(pipe)
+		log.Fatal(err)
+	}
+
+	handle.Write(contents)
+	handle.Close()
+}
+
+func GetPipe(dir string) string {
+	tmpfn := filepath.Join(dir, "tmp-file")
+	err := syscall.Mkfifo(tmpfn, 0600)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return tmpfn
+}
+
+func ExecWithFile(opts ExecOpts) {
+	dir, err := ioutil.TempDir("/tmp/", ".sops")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	pipe := GetPipe(dir)
+	placeholdered := strings.Replace(opts.Command, "{}", pipe, -1)
+	go WritePipe(pipe, []byte(opts.Plaintext))
+
+	cmd := exec.Command("/bin/sh", "-c", placeholdered)
+	cmd.Env = os.Environ()
+
+	if opts.Background {
+		cmd.Start()
+	} else {
+		cmd.Stdin  = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Run()
+	}
+}
+
+func Exec(opts ExecOpts) {
+	env := os.Environ()
+	lines := bytes.Split(opts.Plaintext, []byte("\n"))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == '#' {
+			continue
+		}
+		env = append(env, string(line))
+	}
+
+	cmd := exec.Command("/bin/sh", "-c", opts.Command)
+	cmd.Env = env
+
+	if opts.Background {
+		cmd.Start()
+	} else {
+		cmd.Stdin  = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Run()
+	}
+}

--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -62,12 +62,12 @@ func SwitchUser(username string) {
 
 	uid, _ := strconv.Atoi(user.Uid)
 
-	err = syscall.Setegid(uid)
+	err = syscall.Setgid(uid)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = syscall.Seteuid(uid)
+	err = syscall.Setuid(uid)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Hi there, I'm looking at using sops for an infrastructure project. My current use-case looks something like this:

1. Create an AWS EC2 instance with an IAM instance profile that lets it talk to KMS and is pre-loaded with secrets encrypted by sops
2. At boot, the instance executes sops to decrypt the file and writes it to disk.
3. A daemon that loads this file is started. It uses credentials in this file to connect to a remote database, operate on HMACs, etc.

This daemon can alternatively pull secret values out of its environment, which is where this PR comes in. I would much prefer to pass the credential to this daemon using the environment for a few reasons:
- it's possible to pass the credential without it ever touching the disk in plaintext
- it separates the secret encrypted values from the rest of the config. this is similar to what the `--unencrypted-suffix` does, but we can have configurations that are sourced from the same config file but different environments (eg production vs staging) can substitute in different secrets

My current technique to address this involves using process substitution in a bash shim. This works but isn't the best solution (not least of all because it doesn't work properly on OS X) The shim does something like this:

```
# this is equivalent to `source /some/env/file/on/disk`
# bash silently substitutes the command with something like /dev/pts/40
# which is a pipe connected to the stdout of the process
source <(sops -d /etc/secrets.env)

# /some/config.yml contains regular content, and the secrets are implicitly
# pulled from the environment because they're not found in the config file
/usr/bin/some-program --config /some/config.yml
```

My PR adds an `--exec` flag that does just this. In short, after decryption, dotenv output is added to a one time use environment that is made available to a single child process. This child process can then retrieve the plaintext secret without having to retrieve it from the disk.

I think it'll provide a lot of benefit to folks using dotenv output types. dotenv files are ultimately meant to be loaded into a process' environment, and this does that for you while making it easy to do securely. Writing out secret values to disk and then loading them into your environment opens up room for more risk such as improper permissions on output files, leaking the (now sensitive) environment to more processes than the one that actually needs it, etc. Also I skimmed the issues and saw I'm not the only one looking for something like this (#482, #449)

Some examples:

```
$ ./sops -d test.env
# This is an example file.
hmac_key=abc123
database_password=0th348w0hf3w9ru3pjro

$ ./sops --exec 'bash' -d test.env
bash-3.2$ echo $database_password
0th348w0hf3w9ru3pjro

$ ./external_processor.py
Couldn't find the database password. Make sure to pass it in as an environment variable.

$ ./sops --exec './external_processor.py' -d test.env
Found it! Here: 0th348w0hf3w9ru3pjro

$ cat external_processor.py
#!/usr/bin/python

import os

secret_key = os.getenv("database_password")
if not secret_key:
    print "Couldn't find the database password. Make sure to pass it in as an environment variable."
else:
    print "Found it! Here: {}".format(secret_key)
```

Let me know if you have any questions or request any changes. If this approach seems sane, I can go ahead and write some tests as well.

Thank you for reading!