### PR TITLE
added encrypted-regex option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1193,10 +1193,21 @@ The unencrypted suffix can be set to a different value using the
 Conversely, you can opt in to only encrypt some values in a YAML or JSON file,
 by adding a chosen suffix to those keys and passing it to the ``--encrypted-suffix`` option.
 
+A third method is to use the ``--encrypted-regex`` which will only encrypt values under
+keys that match the supplied regular expression.  For example, this command:
+
+.. code:: bash
+
+	$ sops --encrypt --encrypted-regex '&(data|stringData)' k8s-secrets.yaml
+
+will encrypt the values under the ``data`` and ``stringData`` keys in a YAML file
+containing kubernetes secrets.  It will not encrypt other values that help you to
+navigate the file, like ``metadata`` which contains the secrets' names.
+
 You can also specify these options in the ``.sops.yaml`` config file.
 
-Note: these two options ``--unencrypted-suffix`` and ``--encrypted-suffix`` are mutually exclusive and
-cannot both be used in the same file.
+Note: these three options ``--unencrypted-suffix``, ``--encrypted-suffix``, and ``--encrypted-regex`` are 
+mutually exclusive and cannot both be used in the same file.
 
 Encryption Protocol
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -1207,7 +1207,7 @@ navigate the file, like ``metadata`` which contains the secrets' names.
 You can also specify these options in the ``.sops.yaml`` config file.
 
 Note: these three options ``--unencrypted-suffix``, ``--encrypted-suffix``, and ``--encrypted-regex`` are 
-mutually exclusive and cannot both be used in the same file.
+mutually exclusive and cannot all be used in the same file.
 
 Encryption Protocol
 -------------------

--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -37,6 +37,7 @@ type editExampleOpts struct {
 	editOpts
 	UnencryptedSuffix string
 	EncryptedSuffix   string
+	EncryptedRegex    string
 	KeyGroups         []sops.KeyGroup
 	GroupThreshold    int
 }
@@ -65,6 +66,7 @@ func editExample(opts editExampleOpts) ([]byte, error) {
 			KeyGroups:         opts.KeyGroups,
 			UnencryptedSuffix: opts.UnencryptedSuffix,
 			EncryptedSuffix:   opts.EncryptedSuffix,
+			EncryptedRegex:    opts.EncryptedRegex,
 			Version:           version.Version,
 			ShamirThreshold:   opts.GroupThreshold,
 		},

--- a/cmd/sops/encrypt.go
+++ b/cmd/sops/encrypt.go
@@ -22,6 +22,7 @@ type encryptOpts struct {
 	KeyServices       []keyservice.KeyServiceClient
 	UnencryptedSuffix string
 	EncryptedSuffix   string
+	EncryptedRegex    string
 	KeyGroups         []sops.KeyGroup
 	GroupThreshold    int
 }
@@ -76,6 +77,7 @@ func encrypt(opts encryptOpts) (encryptedFile []byte, err error) {
 			KeyGroups:         opts.KeyGroups,
 			UnencryptedSuffix: opts.UnencryptedSuffix,
 			EncryptedSuffix:   opts.EncryptedSuffix,
+			EncryptedRegex:    opts.EncryptedRegex,
 			Version:           version.Version,
 			ShamirThreshold:   opts.GroupThreshold,
 		},

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -440,6 +440,10 @@ func main() {
 			Usage: "override the encrypted key suffix. When empty, all keys will be encrypted, unless otherwise marked with unencrypted-suffix.",
 		},
 		cli.StringFlag{
+			Name:  "encrypted-regex",
+			Usage: "set the encrypted key suffix. When specified, only keys matching the regex will be encrypted.",
+		},
+		cli.StringFlag{
 			Name:  "config",
 			Usage: "path to sops' config file. If set, sops will not search for the config file recursively.",
 		},
@@ -491,6 +495,7 @@ func main() {
 
 		unencryptedSuffix := c.String("unencrypted-suffix")
 		encryptedSuffix := c.String("encrypted-suffix")
+		encryptedRegex := c.String("encrypted-regex")
 		conf, err := loadConfig(c, fileName, nil)
 		if err != nil {
 			return toExitError(err)
@@ -503,13 +508,29 @@ func main() {
 			if encryptedSuffix == "" {
 				encryptedSuffix = conf.EncryptedSuffix
 			}
+			if encryptedRegex == "" {
+				encryptedRegex = conf.EncryptedRegex
+			}
 		}
-		if unencryptedSuffix != "" && encryptedSuffix != "" {
+
+		cryptRuleCount := 0
+		if unencryptedSuffix != "" {
+			cryptRuleCount++
+		}
+		if encryptedSuffix != "" {
+			cryptRuleCount++
+		}
+		if encryptedRegex != "" {
+			cryptRuleCount++
+		}
+
+		if cryptRuleCount > 1 {
+			return common.NewExitError("Error: cannot use more than one of encrypted_suffix, unencrypted_suffix, or encrypted_regex in the same file", codes.ErrorConflictingParameters)
+		}
+
+		// only supply the default UnencryptedSuffix when EncryptedSuffix and EncryptedRegex are not provided
+		if cryptRuleCount == 0 {
 			return common.NewExitError("Error: cannot use both encrypted_suffix and unencrypted_suffix in the same file", codes.ErrorConflictingParameters)
-		}
-		// only supply the default UnencryptedSuffix when EncryptedSuffix is not provided
-		if unencryptedSuffix == "" && encryptedSuffix == "" {
-			unencryptedSuffix = sops.DefaultUnencryptedSuffix
 		}
 
 		inputStore := inputStore(c, fileName)
@@ -535,6 +556,7 @@ func main() {
 				Cipher:            aes.NewCipher(),
 				UnencryptedSuffix: unencryptedSuffix,
 				EncryptedSuffix:   encryptedSuffix,
+				EncryptedRegex:    encryptedRegex,
 				KeyServices:       svcs,
 				KeyGroups:         groups,
 				GroupThreshold:    threshold,
@@ -656,6 +678,7 @@ func main() {
 					editOpts:          opts,
 					UnencryptedSuffix: unencryptedSuffix,
 					EncryptedSuffix:   encryptedSuffix,
+					EncryptedRegex:    encryptedRegex,
 					KeyGroups:         groups,
 					GroupThreshold:    threshold,
 				})

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -530,7 +530,7 @@ func main() {
 
 		// only supply the default UnencryptedSuffix when EncryptedSuffix and EncryptedRegex are not provided
 		if cryptRuleCount == 0 {
-			return common.NewExitError("Error: cannot use both encrypted_suffix and unencrypted_suffix in the same file", codes.ErrorConflictingParameters)
+			unencryptedSuffix = sops.DefaultUnencryptedSuffix
 		}
 
 		inputStore := inputStore(c, fileName)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -122,6 +122,14 @@ creation_rules:
           version: fooversion
     `)
 
+var sampleConfigWithRegexParameters = []byte(`
+creation_rules:
+  - path_regex: foobar*
+	kms: "1"
+	pgp: "2"
+	encrypted_regex: ^enc:
+    `)
+
 var sampleConfigWithInvalidParameters = []byte(`
 creation_rules:
   - path_regex: foobar*
@@ -271,6 +279,12 @@ func TestLoadConfigFileWithEncryptedSuffix(t *testing.T) {
 	conf, err := parseCreationRuleForFile(parseConfigFile(sampleConfigWithSuffixParameters, t), "barfoo", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "_enc", conf.EncryptedSuffix)
+}
+
+func TestLoadConfigFileWithEncryptedRegex(t *testing.T) {
+	conf, err := loadForFileFromBytes(sampleConfigWithRegexParameters, "barbar", nil)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "^enc:", conf.EncryptedRegex)
 }
 
 func TestLoadConfigFileWithInvalidParameters(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -124,10 +124,10 @@ creation_rules:
 
 var sampleConfigWithRegexParameters = []byte(`
 creation_rules:
-  - path_regex: foobar*
-	kms: "1"
-	pgp: "2"
-	encrypted_regex: ^enc:
+  - path_regex: barbar*
+    kms: "1"
+    pgp: "2"
+    encrypted_regex: "^enc:"
     `)
 
 var sampleConfigWithInvalidParameters = []byte(`
@@ -282,7 +282,7 @@ func TestLoadConfigFileWithEncryptedSuffix(t *testing.T) {
 }
 
 func TestLoadConfigFileWithEncryptedRegex(t *testing.T) {
-	conf, err := loadForFileFromBytes(sampleConfigWithRegexParameters, "barbar", nil)
+	conf, err := parseCreationRuleForFile(parseConfigFile(sampleConfigWithRegexParameters, t), "barbar", nil)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "^enc:", conf.EncryptedRegex)
 }

--- a/sops_test.go
+++ b/sops_test.go
@@ -137,6 +137,58 @@ func TestEncryptedSuffix(t *testing.T) {
 	}
 }
 
+func TestEncryptedRegex(t *testing.T) {
+	branches := TreeBranches{
+		TreeBranch{
+			TreeItem{
+				Key:   "enc:foo",
+				Value: "bar",
+			},
+			TreeItem{
+				Key: "bar",
+				Value: TreeBranch{
+					TreeItem{
+						Key:   "foo",
+						Value: "bar",
+					},
+				},
+			},
+		},
+	}
+	tree := Tree{Branches: branches, Metadata: Metadata{EncryptedRegex: "^enc:"}}
+	expected := TreeBranch{
+		TreeItem{
+			Key:   "enc:foo",
+			Value: "rab",
+		},
+		TreeItem{
+			Key: "bar",
+			Value: TreeBranch{
+				TreeItem{
+					Key:   "foo",
+					Value: "bar",
+				},
+			},
+		},
+	}
+	cipher := reverseCipher{}
+	_, err := tree.Encrypt(bytes.Repeat([]byte("f"), 32), cipher)
+	if err != nil {
+		t.Errorf("Encrypting the tree failed: %s", err)
+	}
+	if !reflect.DeepEqual(tree.Branches[0], expected) {
+		t.Errorf("Trees don't match: \ngot \t\t%+v,\n expected \t\t%+v", tree.Branches[0], expected)
+	}
+	_, err = tree.Decrypt(bytes.Repeat([]byte("f"), 32), cipher)
+	if err != nil {
+		t.Errorf("Decrypting the tree failed: %s", err)
+	}
+	expected[0].Value = "bar"
+	if !reflect.DeepEqual(tree.Branches[0], expected) {
+		t.Errorf("Trees don't match: \ngot\t\t\t%+v,\nexpected\t\t%+v", tree.Branches[0], expected)
+	}
+}
+
 type MockCipher struct{}
 
 func (m MockCipher) Encrypt(value interface{}, key []byte, path string) (string, error) {

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -45,6 +45,7 @@ type Metadata struct {
 	PGPKeys                   []pgpkey    `yaml:"pgp" json:"pgp"`
 	UnencryptedSuffix         string      `yaml:"unencrypted_suffix,omitempty" json:"unencrypted_suffix,omitempty"`
 	EncryptedSuffix           string      `yaml:"encrypted_suffix,omitempty" json:"encrypted_suffix,omitempty"`
+	EncryptedRegex            string      `yaml:"encrypted_regex,omitempty" json:"encrypted_regex,omitempty"`
 	Version                   string      `yaml:"version" json:"version"`
 }
 
@@ -90,6 +91,7 @@ func MetadataFromInternal(sopsMetadata sops.Metadata) Metadata {
 	m.LastModified = sopsMetadata.LastModified.Format(time.RFC3339)
 	m.UnencryptedSuffix = sopsMetadata.UnencryptedSuffix
 	m.EncryptedSuffix = sopsMetadata.EncryptedSuffix
+	m.EncryptedRegex = sopsMetadata.EncryptedRegex
 	m.MessageAuthenticationCode = sopsMetadata.MessageAuthenticationCode
 	m.Version = sopsMetadata.Version
 	m.ShamirThreshold = sopsMetadata.ShamirThreshold
@@ -183,10 +185,23 @@ func (m *Metadata) ToInternal() (sops.Metadata, error) {
 	if err != nil {
 		return sops.Metadata{}, err
 	}
-	if m.UnencryptedSuffix != "" && m.EncryptedSuffix != "" {
-		return sops.Metadata{}, fmt.Errorf("Cannot use both encrypted_suffix and unencrypted_suffix in the same file")
+
+	cryptRuleCount := 0
+	if m.UnencryptedSuffix != "" {
+		cryptRuleCount++
 	}
-	if m.UnencryptedSuffix == "" && m.EncryptedSuffix == "" {
+	if m.EncryptedSuffix != "" {
+		cryptRuleCount++
+	}
+	if m.EncryptedRegex != "" {
+		cryptRuleCount++
+	}
+
+	if cryptRuleCount > 1 {
+		return sops.Metadata{}, fmt.Errorf("Cannot use more than one of encrypted_suffix, unencrypted_suffix, or encrypted_regex in the same file")
+	}
+
+	if cryptRuleCount == 0 {
 		m.UnencryptedSuffix = sops.DefaultUnencryptedSuffix
 	}
 	return sops.Metadata{
@@ -196,6 +211,7 @@ func (m *Metadata) ToInternal() (sops.Metadata, error) {
 		MessageAuthenticationCode: m.MessageAuthenticationCode,
 		UnencryptedSuffix:         m.UnencryptedSuffix,
 		EncryptedSuffix:           m.EncryptedSuffix,
+		EncryptedRegex:            m.EncryptedRegex,
 		LastModified:              lastModified,
 	}, nil
 }


### PR DESCRIPTION
Our team would like to use sops to protect kubernetes secrets in YAML files.

Here's what we want to do:

- encrypt all secret literals, regardless of whether they are under the "data" or "stringData" keys
- *not* encrypt any other values in the file, so we can still easily visually scan the encrypted files (so for instance, we could see the unencrypted secret names in a git diff)
- *not* require developers to put any kind of suffix onto key names
- *not* require any additional pre- or post-processors; we want to use `sops decrypt` and pipe straight to `kubectl apply`.

Here's what we've tried:

- without using encrypted suffix, all values will be encrypted, which makes it impossible to visually scan an encrypted YAML file for fields like metadata.name
- you can add an encrypted suffix like "-encrypted" to the "data" and "stringData" keys, but then the decoded YAML will not be legal, and you'll need a post-processor to apply the files to a k8s cluster (and you'd have to rely on your developers always adding the "-encrypted", or they risk putting unencrypted secrets into the git repo)
- you could use an encrypted suffix like "ata" to automatically encrypting up the "data" and "stringData" keys, but that has the side effect of encrypting the "metadata" keys, which means you can't visually inspect the metadata.name while the file is encrypted
- you could use an encrypted suffix like "stringData" and try to enforce a policy that your developers always put their secrets into "stringData" not "data", but all it takes is one mistake to commit a secret to the git repo

None of these were satisfactory.  So I added a new option: `encrypted-regex`, which lets you encrypt only those values whose keys match the given regular expression.  With this option, you can do this:

```
sops --encrypt --encrypted-regex '^(data|stringData)$'
```

This will encrypt our data and stringData values, but nothing else.

I know there was an objection to PR 385 (https://github.com/mozilla/sops/pull/385) last year on the grounds that the behavior should be moved into the library.  I am hoping that you won't view this PR the same way.  I'm not sure I have the resources for a deep dive into the sops codebase.  But this small change I'm making brings (IMHO) tremendous value to the product wrt kubernetes secrets files.