### PR TITLE
vault kv version and mount names in publish config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 
 before_script:
   - vault server -dev -dev-root-token-id="$VAULT_TOKEN" &
+  - vault secrets enable -version=1 kv
 
 script:
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make; fi'

--- a/README.rst
+++ b/README.rst
@@ -823,6 +823,8 @@ This command requires a ``.sops.yaml`` configuration file. Below is an example:
         recreation_rule:
            pgp: F69E4901EDBAD2D1753F8C67A64535C4163FB307
       - vault_path: "sops/"
+        vault_kv_mount_name: "secret/" # default
+        vault_kv_version: 2 # default
         path_regex: vault/*
 
 The above configuration will place all files under ``s3/*`` into the S3 bucket ``sops-secrets``,
@@ -836,12 +838,16 @@ You would deploy a file to S3 with a command like: ``sops publish s3/app.yaml``
 Publishing to Vault
 *******************
 
-There are two settings for Vault that you can place in your destination rules. The first
-is ``vault_path``, which is required. The second is ``vault_address``, which is optional.
+There are a few settings for Vault that you can place in your destination rules. The first
+is ``vault_path``, which is required. The others are optional, and they are
+``vault_address``, ``vault_kv_mount_name``, ``vault_kv_version``.
 
 ``sops`` uses the official Vault API provided by Hashicorp, which makes use of `environment
 variables <https://www.vaultproject.io/docs/commands/#environment-variables>`_ for
 configuring the client.
+
+``vault_kv_mount_name`` is used if your Vault KV is mounted somewhere other than ``secret/``.
+``vault_kv_version`` supports ``1`` and ``2``, with ``2`` being the default.
 
 Below is an example of publishing to Vault (using token auth with a local dev instance of Vault).
 

--- a/config/config.go
+++ b/config/config.go
@@ -90,14 +90,16 @@ type azureKVKey struct {
 }
 
 type destinationRule struct {
-	PathRegex      string       `yaml:"path_regex"`
-	S3Bucket       string       `yaml:"s3_bucket"`
-	S3Prefix       string       `yaml:"s3_prefix"`
-	GCSBucket      string       `yaml:"gcs_bucket"`
-	GCSPrefix      string       `yaml:"gcs_prefix"`
-	VaultPath      string       `yaml:"vault_path"`
-	VaultAddress   string       `yaml:"vault_address"`
-	RecreationRule creationRule `yaml:"recreation_rule,omitempty"`
+	PathRegex        string       `yaml:"path_regex"`
+	S3Bucket         string       `yaml:"s3_bucket"`
+	S3Prefix         string       `yaml:"s3_prefix"`
+	GCSBucket        string       `yaml:"gcs_bucket"`
+	GCSPrefix        string       `yaml:"gcs_prefix"`
+	VaultPath        string       `yaml:"vault_path"`
+	VaultAddress     string       `yaml:"vault_address"`
+	VaultKVMountName string       `yaml:"vault_kv_mount_name"`
+	VaultKVVersion   int          `yaml:"vault_kv_version"`
+	RecreationRule   creationRule `yaml:"recreation_rule,omitempty"`
 }
 
 type creationRule struct {
@@ -255,7 +257,7 @@ func parseDestinationRuleForFile(conf *configFile, filePath string, kmsEncryptio
 			dest = publish.NewGCSDestination(dRule.GCSBucket, dRule.GCSPrefix)
 		}
 		if dRule.VaultPath != "" {
-			dest = publish.NewVaultDestination(dRule.VaultAddress, dRule.VaultPath)
+			dest = publish.NewVaultDestination(dRule.VaultAddress, dRule.VaultPath, dRule.VaultKVMountName, dRule.VaultKVVersion)
 		}
 	}
 

--- a/functional-tests/.sops.yaml
+++ b/functional-tests/.sops.yaml
@@ -19,4 +19,10 @@ destination_rules:
       reencryption_rule:
         pgp: B611A2F9F11D0FF82568805119F9B5DAEA91FF86
     - vault_path: "functional-test/"
+      vault_kv_mount_name: "secret/"
+      vault_kv_version: 2
       path_regex: test_encrypt_publish_vault.json
+    - vault_path: "functional-test-version-1/"
+      vault_kv_mount_name: "kv/"
+      vault_kv_version: 1
+      path_regex: test_encrypt_publish_vault_version_1.json

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -134,6 +134,35 @@ mod tests {
     }
 
     #[test]
+    fn publish_json_file_vault_version_1() {
+        let file_path = prepare_temp_file("test_encrypt_publish_vault_version_1.json",
+                                          b"{
+    \"foo\": 2,
+    \"bar\": \"baz\"
+}");
+        assert!(Command::new(SOPS_BINARY_PATH)
+            .arg("-e")
+            .arg("-i")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops")
+            .status
+            .success(),
+            "SOPS failed to encrypt a file");
+        assert!(Command::new(SOPS_BINARY_PATH)
+            .arg("publish")
+            .arg("--yes")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops")
+            .status
+            .success(),
+            "sops failed to publish a file to Vault");
+
+        //TODO: Check that file exists in Vault
+    }
+
+    #[test]
     #[ignore]
     fn encrypt_json_file_kms() {
         let kms_arn = env::var(KMS_KEY).expect("Expected $FUNCTIONAL_TEST_KMS_ARN env var to be set");


### PR DESCRIPTION
Adds support for publishing to vault using KV v1 and a different mount name (or multiple).

Also further expands the "destination rule config" unit tests.

Supporting kv v1 and a different mount name came back to me from user testing of `sops publish`.