### PR TITLE
Document how to operate on stdin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1007,6 +1007,12 @@ sops with the ``--input-type`` flag upon decryption. For example:
 
 	$ sops -d --input-type json myfile.json.enc
 
+When operating on stdin, use the ``--input-type`` and ``--output-type`` flags as follows:
+
+.. code:: bash
+
+    $ cat myfile.json | sops --input-type json --output-type json -d /dev/stdin
+
 YAML anchors
 ~~~~~~~~~~~~
 ``sops`` only supports a subset of ``YAML``'s many types. Encrypting YAML files that


### PR DESCRIPTION
Adds some short documentation about _stdin_, addressing https://github.com/mozilla/sops/issues/330#issuecomment-381687801 and one of the items in #337.