### PR TITLE
Sanitize hostname used for AWS STS role session name

### DIFF
--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -167,7 +167,7 @@ func (key MasterKey) createStsSession(config aws.Config, sess *session.Session) 
 	}
 	stsRoleSessionNameRe, err := regexp.Compile("[^a-zA-Z0-9=,.@-]+")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to compile STS role session name regex: %v", err)
 	}
 	sanitizedHostname := stsRoleSessionNameRe.ReplaceAllString(hostname, "")
 	stsService := sts.New(sess)

--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -165,8 +165,13 @@ func (key MasterKey) createStsSession(config aws.Config, sess *session.Session) 
 	if err != nil {
 		return nil, err
 	}
+	stsRoleSessionNameRe, err := regexp.Compile("[^a-zA-Z0-9=,.@-]+")
+	if err != nil {
+		return nil, err
+	}
+	sanitizedHostname := stsRoleSessionNameRe.ReplaceAllString(hostname, "")
 	stsService := sts.New(sess)
-	name := "sops@" + hostname
+	name := "sops@" + sanitizedHostname
 	out, err := stsService.AssumeRole(&sts.AssumeRoleInput{
 		RoleArn: &key.Role, RoleSessionName: &name})
 	if err != nil {


### PR DESCRIPTION
From official docs for --role-session-name (https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html):
> The regex used to validate this parameter is a string of characters consisting of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-

This fixes #441, which occurs when the hostname includes spaces and parentheses