### PR TITLE
Sort sops parameters in dotenv file

### DIFF
--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"go.mozilla.org/sops"
@@ -98,7 +99,14 @@ func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	for key, value := range mdItems {
+	var keys []string
+	for k := range mdItems {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		var value = mdItems[key]
 		if value == nil {
 			continue
 		}


### PR DESCRIPTION
Fixes https://github.com/mozilla/sops/issues/565 by sorting the parameters as suggested by @autrilla 

The sops keys are nice and sorted after this change:

```
asd=ENC[AES256_GCM,data:4A==,iv:shBMbkqdEUuD8bmVADE1ZOkVQsCtjXQyFjC9wo9fsyk=,tag:xjXTdQ79jjdNWzShYFOyeA==,type:str]
asd2=ENC[AES256_GCM,data:O9uXzAs=,iv:OMBL1mtaiSf8toJLhZSsx95jjqAQ2UJ7VzOdmouUdug=,tag:jqN6yWUffmJ37tE7CEzZ7g==,type:str]
sops_gcp_kms__list_0__map_created_at=2019-11-15T21:01:09Z
sops_gcp_kms__list_0__map_enc=CiQAw/cKVesnu1HnGwfoDuw8K+zSJ9GI/6UuDKKZ+ctdYx8yo7wSSQCF91q7qCn9ruM7LMFrFhTa5w5gzX9388KSkpolvVwJ1shXKqKVzmSBXPd4QAlCgue5f9qjBeu+ISjGbsmvf0hcams7VoxFs4c=
sops_gcp_kms__list_0__map_resource_id=projects/REDACTED/locations/global/keyRings/REDACTED/cryptoKeys/REDACTED
sops_lastmodified=2019-11-15T21:59:38Z
sops_mac=ENC[AES256_GCM,data:qqJNcmySnpGIskNYspvhXN/A1WU6wepWdN3gZCy7VJwacjbty/AKJny4plhnoUZvySFq/7se+1DNWzuQIOaFd2b5uJKqdpn2oz7DbNK1g+KchQ6eXwXtMCsPlS4Ai++i3fUeA7bL/zDMm/gEi/gpFBswGLS8DFVtWgfrT+5o6fA=,iv:UJF65kBQeHBhH3AI3BEdUReIc2G8yHjqbMRY1eC/ZYY=,tag:IOjPsmhF9l58txPjC6VgCw==,type:str]
sops_unencrypted_suffix=_unencrypted
sops_version=3.4.0
```

I modified the file 2x to be sure they were always sorted.
