### PR TITLE
Sort sops parameters in dotenv file

### DIFF
--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"go.mozilla.org/sops"
@@ -98,7 +99,14 @@ func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	for key, value := range mdItems {
+	var keys []string
+	for k := range mdItems {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		var value = mdItems[key]
 		if value == nil {
 			continue
 		}


### PR DESCRIPTION
Fixes https://github.com/mozilla/sops/issues/565 by sorting the parameters as suggested by @autrilla 

Previous PR was off the wrong branch: https://github.com/mozilla/sops/pull/574

The sops keys are nice and sorted after this change:

```
asd=ENC[AES256_GCM,data:4A==,iv:shBMbkqdEUuD8bmVADE1ZOkVQsCtjXQyFjC9wo9fsyk=,tag:xjXTdQ79jjdNWzShYFOyeA==,type:str]
asd2=ENC[AES256_GCM,data:2icjt5HL,iv:Mw8u1zDyEFItCsg3d462KRS3pbhy0IrB1rtXG25wpUU=,tag:8R3FFj8U2o/HHriegTV8uA==,type:str]
asd2asdasd=ENC[AES256_GCM,data:yg==,iv:Erq6FlUpPFU1vlXlOEW8D2hqnRzW7webtaeOiDTQYKk=,tag:LZ7wk1n6EZjGeD/gChTCkg==,type:str]
sops_gcp_kms__list_0__map_created_at=2019-11-15T21:01:09Z
sops_gcp_kms__list_0__map_enc=CiQAw/cKVesnu1HnGwfoDuw8K+zSJ9GI/6UuDKKZ+ctdYx8yo7wSSQCF91q7qCn9ruM7LMFrFhTa5w5gzX9388KSkpolvVwJ1shXKqKVzmSBXPd4QAlCgue5f9qjBeu+ISjGbsmvf0hcams7VoxFs4c=
sops_gcp_kms__list_0__map_resource_id=projects/REDACTED/locations/global/keyRings/REDACTED/cryptoKeys/REDACTED
sops_lastmodified=2019-11-15T22:23:19Z
sops_mac=ENC[AES256_GCM,data:6CCOCh2/2M9J1aPMGxVQzbAfbZxesAOic/BtTkecy8Lx0LzWxXggWBNoBh7fMdJS50CbMQhLYXLxrsGKwgXOlAfKH1ip8sSq15ZbNVKQCuNm5gRmrmqsrrCx8PKDUxC+9dKol0M6pDuh1bcFcBaJAMsQxwuH4zGeBgJ7GRXd9kg=,iv:+zvJg4xpzb11yoAckCBCHMQ0Rwh3ShBH9h5jiru33Hg=,tag:MtFsO5yRnI1rS9O0e/IO4w==,type:str]
sops_unencrypted_suffix=_unencrypted
sops_version=3.4.0

```

I modified the file 2x to be sure they were always sorted. Retested off of develop, still functional.
