### PR TITLE
Publishing improvements: directory walking; prevent Vault unneeded version increment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -968,6 +968,7 @@ This command requires a ``.sops.yaml`` configuration file. Below is an example:
         vault_kv_mount_name: "secret/" # default
         vault_kv_version: 2 # default
         path_regex: vault/*
+        omit_extensions: true
 
 The above configuration will place all files under ``s3/*`` into the S3 bucket ``sops-secrets``,
 all files under ``gcs/*`` into the GCS bucket ``sops-secrets``, and the contents of all files under
@@ -976,6 +977,11 @@ published to S3 and GCS, it will decrypt them and re-encrypt them using the
 ``F69E4901EDBAD2D1753F8C67A64535C4163FB307`` pgp key.
 
 You would deploy a file to S3 with a command like: ``sops publish s3/app.yaml``
+
+To publish all files in selected directory recursively, you need to specify ``--recurse`` flag.
+
+If you don't want file extension to appear in destination secret path, use ``--omit-extensions``
+flag or same ``.sops.yaml`` option.
 
 Publishing to Vault
 *******************
@@ -990,6 +996,9 @@ configuring the client.
 
 ``vault_kv_mount_name`` is used if your Vault KV is mounted somewhere other than ``secret/``.
 ``vault_kv_version`` supports ``1`` and ``2``, with ``2`` being the default.
+
+If destination secret path already exists in Vault and contains same data as source file, it will
+be skipped.
 
 Below is an example of publishing to Vault (using token auth with a local dev instance of Vault).
 

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -224,7 +224,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "recursive",
-					Usage: "If source path is directory, publish all its content recursively",
+ 					Usage: "If the source path is a directory, publish all its content recursively",
 				},
 				cli.BoolFlag{
 					Name:  "verbose",

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -211,12 +211,16 @@ func main() {
 		},
 		{
 			Name:      "publish",
-			Usage:     "Publish sops file to a configured destination",
+			Usage:     "Publish sops file or directory to a configured destination",
 			ArgsUsage: `file`,
 			Flags: append([]cli.Flag{
 				cli.BoolFlag{
 					Name:  "yes, y",
 					Usage: `pre-approve all changes and run non-interactively`,
+				},
+				cli.BoolFlag{
+					Name:  "recurse",
+					Usage: "If source path is directory, publish all its content recursively",
 				},
 				cli.BoolFlag{
 					Name:  "verbose",
@@ -235,14 +239,13 @@ func main() {
 					return common.NewExitError("Error: no file specified", codes.NoFileSpecified)
 				}
 				fileName := c.Args()[0]
-				inputStore := inputStore(c, fileName)
 				err = publishcmd.Run(publishcmd.Opts{
 					ConfigPath:  configPath,
 					InputPath:   fileName,
-					InputStore:  inputStore,
 					Cipher:      aes.NewCipher(),
 					KeyServices: keyservices(c),
 					Interactive: !c.Bool("yes"),
+					Recurse:     c.Bool("recurse"),
 				})
 				if cliErr, ok := err.(*cli.ExitError); ok && cliErr != nil {
 					return cliErr

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -219,6 +219,10 @@ func main() {
 					Usage: `pre-approve all changes and run non-interactively`,
 				},
 				cli.BoolFlag{
+					Name:  "omit-extensions",
+					Usage: "Omit file extensions in destination path when publishing sops file to configured destinations",
+				},
+				cli.BoolFlag{
 					Name:  "recurse",
 					Usage: "If source path is directory, publish all its content recursively",
 				},
@@ -240,12 +244,13 @@ func main() {
 				}
 				fileName := c.Args()[0]
 				err = publishcmd.Run(publishcmd.Opts{
-					ConfigPath:  configPath,
-					InputPath:   fileName,
-					Cipher:      aes.NewCipher(),
-					KeyServices: keyservices(c),
-					Interactive: !c.Bool("yes"),
-					Recurse:     c.Bool("recurse"),
+					ConfigPath:     configPath,
+					InputPath:      fileName,
+					Cipher:         aes.NewCipher(),
+					KeyServices:    keyservices(c),
+					Interactive:    !c.Bool("yes"),
+					OmitExtensions: c.Bool("omit-extensions"),
+					Recurse:        c.Bool("recurse"),
 				})
 				if cliErr, ok := err.(*cli.ExitError); ok && cliErr != nil {
 					return cliErr

--- a/config/config.go
+++ b/config/config.go
@@ -100,6 +100,7 @@ type destinationRule struct {
 	VaultKVMountName string       `yaml:"vault_kv_mount_name"`
 	VaultKVVersion   int          `yaml:"vault_kv_version"`
 	RecreationRule   creationRule `yaml:"recreation_rule,omitempty"`
+	OmitExtensions   bool         `yaml:"omit_extensions"`
 }
 
 type creationRule struct {
@@ -133,6 +134,7 @@ type Config struct {
 	EncryptedSuffix   string
 	EncryptedRegex    string
 	Destination       publish.Destination
+	OmitExtensions    bool
 }
 
 func getKeyGroupsFromCreationRule(cRule *creationRule, kmsEncryptionContext map[string]*string) ([]sops.KeyGroup, error) {
@@ -266,6 +268,7 @@ func parseDestinationRuleForFile(conf *configFile, filePath string, kmsEncryptio
 		return nil, err
 	}
 	config.Destination = dest
+	config.OmitExtensions = dRule.OmitExtensions
 
 	return config, nil
 }

--- a/publish/vault.go
+++ b/publish/vault.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	vault "github.com/hashicorp/vault/api"
 )
 
@@ -62,6 +63,17 @@ func (vaultd *VaultDestination) UploadUnencrypted(data map[string]interface{}, f
 		err = client.SetAddress(vaultd.vaultAddress)
 		if err != nil {
 			return err
+		}
+	}
+
+	existingSecret, err := client.Logical().Read(vaultd.secretsPath(fileName))
+	if err != nil {
+		return err
+	}
+	if existingSecret != nil {
+		if cmp.Equal(data, existingSecret.Data["data"]) {
+			fmt.Printf("Secret in %s is already up-to-date.\n", vaultd.secretsPath(fileName))
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Hello.
This PR contains 3 changes in 3 corresponding commits:
- implement -recurse cmd option for directory walking for publish command, so you can publish a bunch of files, preserving structure;
- implement -omit-extensions cmd option to omit file extension in destination secret path. Can be specified in .sops.yaml;
- implement pre-check for already existing Vault secret, to avoid version increment if data not changed.

