### PR TITLE
smaller docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/.git
+/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM golang:1.12
+FROM golang:1.12-alpine3.10 AS builder
+
+RUN apk --no-cache add make
 
 COPY . /go/src/go.mozilla.org/sops
 WORKDIR /go/src/go.mozilla.org/sops
 
 RUN CGO_ENABLED=1 make install
-RUN apt-get update
-RUN apt-get install -y vim python-pip emacs
-RUN pip install awscli
+
+
+FROM alpine:3.10
+
+RUN apk --no-cache add \
+  vim ca-certificates
 ENV EDITOR vim
+COPY --from=builder /go/bin/sops /usr/local/bin/sops


### PR DESCRIPTION
Current docker images in [`mozilla/sops`](https://hub.docker.com/r/mozilla/sops/) are really large:

```
$ docker pull mozilla/sops
Using default tag: latest
latest: Pulling from mozilla/sops
16ea0e8c8879: Pull complete
50024b0106d5: Pull complete
ff95660c6937: Pull complete
9c7d0e5c0bc2: Pull complete
2a19d2e6789c: Pull complete
7b1f65f09b49: Pull complete
5032d39c58b8: Pull complete
d0950f7151dd: Pull complete
a192244379be: Pull complete
156891fecda0: Pull complete
dd2a84f83da0: Pull complete
dc4ac32b2d3a: Pull complete
Digest: sha256:eec1afc89e907e46f5cca94269c858a4b42d7a63874626af63110745ea59cb00
Status: Downloaded newer image for mozilla/sops:latest
docker.io/mozilla/sops:latest
$ docker images mozilla/sops
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
mozilla/sops        latest              6a8e325d2d11        5 weeks ago         2.3GB
```
It's inconvenient as it takes much time to download images and requires more disk space. I want to have official images smaller.

This change shrinks the size of the docker image:
```
$ docker build -t sops .
...
$ docker images sops
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
sops                latest              c4f6175388ce        About a minute ago   64.4MB
```

Notice: This change breaks following compatibiliteis:

* The base image changes from debian to apline. This results many changes, for example, users not longer be able to use `bash` and have to use `sh` instead.
* This change removes `awscli` and `emacs` from the container image.
    * I believe it's better to remove those packages as not all users need them. Users who need those packages can create their own images based on this new image.
    * Installing them requires about more 250MB (+100 MB for awscli, +150MB for emacs).
