### PR TITLE
Added version to docker tag #542

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,29 +74,29 @@ jobs:
           name: Tag & Push containers
           command: |
             #latest
-            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "latest"
+            bin/ci/deploy_dockerhub.sh "latest"
 
             # by sha
             echo "Tag and push mozilla/sops:$CIRCLE_SHA1"
             docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
-            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "$CIRCLE_SHA1"
+            bin/ci/deploy_dockerhub.sh "$CIRCLE_SHA1"
 
             # by semver
             # v1.2.3
             if [ ! -z $PATCH ];then
               echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR.$PATCH"
               docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR.$PATCH"
-              src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR.$PATCH"
+              bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR.$PATCH"
             fi
             # v1.2
             if [ ! -z $MINOR ];then
               echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR"
               docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR"
-              src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR"
+              bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR"
             fi
             # v1
             echo "Tag and Push mozilla/sops:v$MAJOR"
             docker tag mozilla/sops "mozilla/sops:v$MAJOR"
-            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR"
+            bin/ci/deploy_dockerhub.sh "v$MAJOR"
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
       - run: 
           name: semver check
           command: |
-            
             MAJOR=$(echo ${CIRCLE_TAG#v} | cut -d"." -f1)
             MINOR=$(echo ${CIRCLE_TAG#v} | cut -d"." -f2)
             PATCH=$(echo ${CIRCLE_TAG#v} | cut -d"." -f3)
@@ -53,19 +52,6 @@ jobs:
             EOF
             exit 1
             fi
-      - run:
-          when: on_fail
-          name: semver error message
-          command: |
-            cat \<< EOF
-            Failure Info:
-
-            This job uses a simple semver library to ensure the TAG is a valid version to publish.
-
-            - This should only run on workflows triggered by a tag. 
-            - The tag name should be a semver like 'v1.2.3' 
-            - The version should follow conventions documented at https://github.com/fsaintjacques/semver-tool
-            EOF
       - run:
           name: Build containers
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,15 +33,26 @@ jobs:
       - run: 
           name: semver check
           command: |
-            curl "https://raw.githubusercontent.com/fsaintjacques/semver-tool/d66113a6803dbffca2a3830e207a6795a8516cd1/src/semver" > semver.bash
-            sudo mv semver.bash /usr/local/bin/semver
-            sudo chmod a+x  /usr/local/bin/semver
-            MAJOR=$(semver get major ${CIRCLE_TAG#v})
-            MINOR=$(semver get minor ${CIRCLE_TAG#v})
-            PATCH=$(semver get patch ${CIRCLE_TAG#v})
+            
+            MAJOR=$(echo ${CIRCLE_TAG#v} | cut -d"." -f1)
+            MINOR=$(echo ${CIRCLE_TAG#v} | cut -d"." -f2)
+            PATCH=$(echo ${CIRCLE_TAG#v} | cut -d"." -f3)
             echo "export MAJOR=${MAJOR}" >> $BASH_ENV
             echo "export MINOR=${MINOR}" >> $BASH_ENV
             echo "export PATCH=${PATCH}" >> $BASH_ENV
+
+            if [ -z $MAJOR ];then
+            cat \<< EOF
+            Failure Info:
+
+            This job uses the semver from the git TAG as the public version to publish.
+
+            - This should only run on workflows triggered by a tag. 
+            - The tag name should be a semver like 'v1.2.3' 
+            - The version should follow conventions documented at https://github.com/fsaintjacques/semver-tool
+            EOF
+            exit 1
+            fi
       - run:
           when: on_fail
           name: semver error message
@@ -66,20 +77,23 @@ jobs:
             src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "latest"
 
             # by sha
-
             echo "Tag and push mozilla/sops:$CIRCLE_SHA1"
             docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
             src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "$CIRCLE_SHA1"
 
             # by semver
             # v1.2.3
-            echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR.$PATCH"
-            docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR.$PATCH"
-            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR.$PATCH"
+            if [ ! -z $PATCH ];then
+              echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR.$PATCH"
+              docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR.$PATCH"
+              src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR.$PATCH"
+            fi
             # v1.2
-            echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR"
-            docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR"
-            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR"
+            if [ ! -z $MINOR ];then
+              echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR"
+              docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR"
+              src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR"
+            fi
             # v1
             echo "Tag and Push mozilla/sops:v$MAJOR"
             docker tag mozilla/sops "mozilla/sops:v$MAJOR"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,21 @@
-version: 2
+version: 2.1
+
+workflows:
+  build-and-deploy:
+    jobs:
+      - build
+      - push:     
+          filters:
+            tags:
+              only: /^v.*/   
+            branches:
+              ignore: /.*/
 jobs:
   build:
     working_directory: /go/src/go.mozilla.org/sops
     docker:
       - image: circleci/golang:1.13
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker
@@ -12,10 +24,65 @@ jobs:
           command: |
             docker build -t mozilla/sops .
             docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
-      - run:
-          name: Push containers
+
+  push:
+    machine: true
+    resource_class: large
+    steps:
+      - checkout
+      - run: 
+          name: semver check
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                ${GOPATH}/src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "latest"
-                ${GOPATH}/src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "$CIRCLE_SHA1"
-            fi
+            curl "https://raw.githubusercontent.com/fsaintjacques/semver-tool/d66113a6803dbffca2a3830e207a6795a8516cd1/src/semver" > semver.bash
+            sudo mv semver.bash /usr/local/bin/semver
+            sudo chmod a+x  /usr/local/bin/semver
+            MAJOR=$(semver get major ${CIRCLE_TAG#v})
+            MINOR=$(semver get minor ${CIRCLE_TAG#v})
+            PATCH=$(semver get patch ${CIRCLE_TAG#v})
+            echo "export MAJOR=${MAJOR}" >> $BASH_ENV
+            echo "export MINOR=${MINOR}" >> $BASH_ENV
+            echo "export PATCH=${PATCH}" >> $BASH_ENV
+      - run:
+          when: on_fail
+          name: semver error message
+          command: |
+            cat \<< EOF
+            Failure Info:
+
+            This job uses a simple semver library to ensure the TAG is a valid version to publish.
+
+            - This should only run on workflows triggered by a tag. 
+            - The tag name should be a semver like 'v1.2.3' 
+            - The version should follow conventions documented at https://github.com/fsaintjacques/semver-tool
+            EOF
+      - run:
+          name: Build containers
+          command: |
+            docker build -t mozilla/sops .
+      - run:
+          name: Tag & Push containers
+          command: |
+            #latest
+            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "latest"
+
+            # by sha
+
+            echo "Tag and push mozilla/sops:$CIRCLE_SHA1"
+            docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
+            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "$CIRCLE_SHA1"
+
+            # by semver
+            # v1.2.3
+            echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR.$PATCH"
+            docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR.$PATCH"
+            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR.$PATCH"
+            # v1.2
+            echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR"
+            docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR"
+            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR"
+            # v1
+            echo "Tag and Push mozilla/sops:v$MAJOR"
+            docker tag mozilla/sops "mozilla/sops:v$MAJOR"
+            src/go.mozilla.org/sops/bin/ci/deploy_dockerhub.sh "v$MAJOR"
+
+


### PR DESCRIPTION
This change accesses the environment variable CIRCLE_TAG to address #542 

Changes:

1. Break docker push into its own job, runs only on tag creation
2. Use machine executor for docker push job (a little faster since it avoids shipping docker context around)
3. use the CIRCLE_TAG variable provided on tag builds


Options:

1. We can merge jobs back AND/OR
2. We can still publish SHA on master and just AMJOR/MINOR/PATCH, etc on tags


I ran in my own circle spae to test tagging.  I obviously dont have your docker creds, so the push fails, but the tagging works.


Run:
``` bash
#!/bin/bash -eo pipefail
docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
# Update all semvers affected
echo "Tag mozilla/sops:$MAJOR"
docker tag mozilla/sops "mozilla/sops:$MAJOR"
echo "Tag mozilla/sops:$MAJOR.$MINOR"
docker tag mozilla/sops "mozilla/sops:$MAJOR.$MINOR"
echo "Tag mozilla/sops:$MAJOR.$MINOR.$PATCH"
docker tag mozilla/sops "mozilla/sops:$MAJOR.$MINOR.$PATCH"
docker images
```

Output
```
Tag mozilla/sops:0
Tag mozilla/sops:0.0
Tag mozilla/sops:0.0.5
REPOSITORY          TAG                                        IMAGE ID            CREATED                  SIZE
mozilla/sops        0                                          c533f52a658b        Less than a second ago   2.3GB
mozilla/sops        0.0                                        c533f52a658b        Less than a second ago   2.3GB
mozilla/sops        0.0.5                                      c533f52a658b        Less than a second ago   2.3GB
mozilla/sops        57f8a1fef66eb850dff6e43f06b1def877cff6af   c533f52a658b        Less than a second ago   2.3GB
mozilla/sops        latest                                     c533f52a658b        Less than a second ago   2.3GB
golang              1.12                                       8639ad3fc384        6 days ago               810MB
```