### PR TITLE
Alpine-based docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,16 +56,20 @@ jobs:
           name: Build containers
           command: |
             docker build -t mozilla/sops .
+            docker build -f Dockerfile.alpine -t mozilla/sops:alpine .
       - run:
           name: Tag & Push containers
           command: |
             #latest
             bin/ci/deploy_dockerhub.sh "latest"
+            bin/ci/deploy_dockerhub.sh "alpine"
 
             # by sha
             echo "Tag and push mozilla/sops:$CIRCLE_SHA1"
             docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
             bin/ci/deploy_dockerhub.sh "$CIRCLE_SHA1"
+
+            # no sha for alpine
 
             # by semver
             # v1.2.3
@@ -73,16 +77,26 @@ jobs:
               echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR.$PATCH"
               docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR.$PATCH"
               bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR.$PATCH"
+
+              echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR.$PATCH-alpine"
+              docker tag mozilla/sops:alpine "mozilla/sops:v$MAJOR.$MINOR.$PATCH-alpine"
+              bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR.$PATCH-alpine"
             fi
             # v1.2
             if [ ! -z $MINOR ];then
               echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR"
               docker tag mozilla/sops "mozilla/sops:v$MAJOR.$MINOR"
               bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR"
+
+              echo "Tag and Push mozilla/sops:v$MAJOR.$MINOR-alpine"
+              docker tag mozilla/sops:alpine "mozilla/sops:v$MAJOR.$MINOR-alpine"
+              bin/ci/deploy_dockerhub.sh "v$MAJOR.$MINOR-alpine"
             fi
             # v1
             echo "Tag and Push mozilla/sops:v$MAJOR"
             docker tag mozilla/sops "mozilla/sops:v$MAJOR"
             bin/ci/deploy_dockerhub.sh "v$MAJOR"
 
-
+            echo "Tag and Push mozilla/sops:v$MAJOR-alpine"
+            docker tag mozilla/sops:alpine "mozilla/sops:v$MAJOR-alpine"
+            bin/ci/deploy_dockerhub.sh "v$MAJOR-alpine"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/.git
+/Dockerfile
+/Dockerfile.alpine

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,17 @@
+FROM golang:1.12-alpine3.10 AS builder
+
+RUN apk --no-cache add make
+
+COPY . /go/src/go.mozilla.org/sops
+WORKDIR /go/src/go.mozilla.org/sops
+
+RUN CGO_ENABLED=1 make install
+
+
+FROM alpine:3.10
+
+RUN apk --no-cache add \
+  vim ca-certificates
+ENV EDITOR vim
+COPY --from=builder /go/bin/sops /usr/local/bin/sops
+ENTRYPOINT ["/usr/local/bin/sops"]


### PR DESCRIPTION
Replaces #604 .

I want alpine-based docker images for sops, as it's small and easy to use:

* The current image uses 2 GB+:
    ```
    $ docker images mozilla/sops
    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
    mozilla/sops        latest              6a8e325d2d11        5 weeks ago         2.3GB
    ```
* The alpine-based image uses only 65MB:
    ```
    $ docker build -t sops -f Dockerfile.alpine .
    ...
    $ docker images sops
    REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
    sops                latest              c4f6175388ce        About a minute ago   64.4MB
    ```

And this pull request also changes `.circleci/config.yml` to deploy alpine based images as `mozilla/sops:3.5.0-alpine` and `mozilla/sops:alpine`.
I believe we don't need alpine images for every commits and only images for tags are enough useful.
