### PR TITLE
Fix newline encoding for dotenv store

### DIFF
--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -81,7 +81,7 @@ func (store *Store) LoadPlainFile(in []byte) (sops.TreeBranches, error) {
 			}
 			branch = append(branch, sops.TreeItem{
 				Key:   string(line[:pos]),
-				Value: string(line[pos+1:]),
+				Value: strings.Replace(string(line[pos+1:]), "\\n", "\n", -1),
 			})
 		}
 	}
@@ -119,7 +119,8 @@ func (store *Store) EmitPlainFile(in sops.TreeBranches) ([]byte, error) {
 		if comment, ok := item.Key.(sops.Comment); ok {
 			line = fmt.Sprintf("#%s\n", comment.Value)
 		} else {
-			line = fmt.Sprintf("%s=%s\n", item.Key, item.Value)
+			value := strings.Replace(item.Value.(string), "\n", "\\n", -1)
+			line = fmt.Sprintf("%s=%s\n", item.Key, value)
 		}
 		buffer.WriteString(line)
 	}

--- a/stores/dotenv/store_test.go
+++ b/stores/dotenv/store_test.go
@@ -13,6 +13,7 @@ VAR1=val1
 VAR2=val2
 #comment
 VAR3_unencrypted=val3
+VAR4=val4\nval4
 `, "\n"))
 
 var BRANCH = sops.TreeBranch{
@@ -31,6 +32,10 @@ var BRANCH = sops.TreeBranch{
 	sops.TreeItem{
 		Key:   "VAR3_unencrypted",
 		Value: "val3",
+	},
+	sops.TreeItem{
+		Key:   "VAR4",
+		Value: "val4\nval4",
 	},
 }
 

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -403,6 +403,10 @@ var ExampleFlatTree = sops.Tree{
 				Key:   "example_key",
 				Value: "example_value",
 			},
+			sops.TreeItem{
+				Key:   "example_multiline",
+				Value: "foo\nbar\nbaz",
+			},
 		},
 	},
 }


### PR DESCRIPTION
When reading and writing dotenv files, we need to make sure to encode/decode newline characters. SOPS does not currently do this, as can be seen below:

```console
$ echo '{"foo": "foo\nbar\nbaz"}' > plaintext.json
$ sops -e --output ciphertext.json plaintext.json
$ sops -d --output-type dotenv ciphertext.json
foo=foo
bar
baz
```

This output is invalid and cannot even be fed back into SOPS:

```console
$ sops -d --output-type dotenv --output plaintext.env ciphertext.json
$ sops -e plaintext.env
Error unmarshalling file: invalid dotenv input line: bar
```

This commit fixes the issue, such that the final `sops -d ...` command above produces the correct output:

```console
$ sops -d --output-type dotenv ciphertext.json
foo=foo\nbar\nbaz
```