### PR TITLE
Support compact-json format

### DIFF
--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -51,7 +51,15 @@ func newIniStore() Store {
 }
 
 func newJsonStore() Store {
-	return &json.Store{}
+	return &json.Store{
+		Compact: false,
+	}
+}
+
+func newCompactJsonStore() Store {
+	return &json.Store{
+		Compact: true,
+	}
 }
 
 func newYamlStore() Store {
@@ -59,11 +67,12 @@ func newYamlStore() Store {
 }
 
 var storeConstructors = map[Format]storeConstructor{
-	Binary: newBinaryStore,
-	Dotenv: newDotenvStore,
-	Ini:    newIniStore,
-	Json:   newJsonStore,
-	Yaml:   newYamlStore,
+	Binary:      newBinaryStore,
+	Dotenv:      newDotenvStore,
+	Ini:         newIniStore,
+	Json:        newJsonStore,
+	Yaml:        newYamlStore,
+	CompactJson: newCompactJsonStore,
 }
 
 // DecryptTreeOpts are the options needed to decrypt a tree

--- a/cmd/sops/formats/formats.go
+++ b/cmd/sops/formats/formats.go
@@ -11,14 +11,16 @@ const (
 	Ini
 	Json
 	Yaml
+	CompactJson
 )
 
 var stringToFormat = map[string]Format{
-	"binary": Binary,
-	"dotenv": Dotenv,
-	"ini":    Ini,
-	"json":   Json,
-	"yaml":   Yaml,
+	"binary":       Binary,
+	"dotenv":       Dotenv,
+	"ini":          Ini,
+	"json":         Json,
+	"compact-json": CompactJson,
+	"yaml":         Yaml,
 }
 
 // FormatFromString returns a Format from a string.

--- a/cmd/sops/formats/formats_test.go
+++ b/cmd/sops/formats/formats_test.go
@@ -12,6 +12,7 @@ func TestFormatFromString(t *testing.T) {
 	assert.Equal(t, Ini, FormatFromString("ini"))
 	assert.Equal(t, Yaml, FormatFromString("yaml"))
 	assert.Equal(t, Json, FormatFromString("json"))
+	assert.Equal(t, CompactJson, FormatFromString("compact-json"))
 }
 
 func TestFormatForPath(t *testing.T) {

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -520,7 +520,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "output-type",
-			Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
+			Usage: "currently json, compact-json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
 		},
 		cli.BoolFlag{
 			Name:  "show-master-keys, s",

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -12,6 +12,8 @@ import (
 
 // Store handles storage of JSON data.
 type Store struct {
+	// Compact with `true` outputs json without insignificant whitespace letters.
+	Compact bool
 }
 
 // BinaryStore handles storage of binary data in a JSON envelope.
@@ -211,7 +213,12 @@ func (store Store) treeBranchFromJSON(in []byte) (sops.TreeBranch, error) {
 
 func (store Store) reindentJSON(in []byte) ([]byte, error) {
 	var out bytes.Buffer
-	err := json.Indent(&out, in, "", "\t")
+	var err error
+	if store.Compact {
+		err = json.Compact(&out, in)
+	} else {
+		err = json.Indent(&out, in, "", "\t")
+	}
 	return out.Bytes(), err
 }
 

--- a/stores/json/store_test.go
+++ b/stores/json/store_test.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -213,10 +214,14 @@ func TestEncodeSimpleJSON(t *testing.T) {
 			Value: false,
 		},
 	}
-	out, err := Store{}.jsonFromTreeBranch(branch)
-	assert.Nil(t, err)
-	expected, _ := Store{}.treeBranchFromJSON(out)
-	assert.Equal(t, expected, branch)
+	for _, compact := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compact=%v", compact), func(t *testing.T) {
+			out, err := Store{}.jsonFromTreeBranch(branch)
+			assert.Nil(t, err)
+			expected, _ := Store{}.treeBranchFromJSON(out)
+			assert.Equal(t, expected, branch)
+		})
+	}
 }
 
 func TestEncodeJSONWithEscaping(t *testing.T) {
@@ -234,10 +239,14 @@ func TestEncodeJSONWithEscaping(t *testing.T) {
 			Value: 2.0,
 		},
 	}
-	out, err := Store{}.jsonFromTreeBranch(branch)
-	assert.Nil(t, err)
-	expected, _ := Store{}.treeBranchFromJSON(out)
-	assert.Equal(t, expected, branch)
+	for _, compact := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compact=%v", compact), func(t *testing.T) {
+			out, err := Store{}.jsonFromTreeBranch(branch)
+			assert.Nil(t, err)
+			expected, _ := Store{}.treeBranchFromJSON(out)
+			assert.Equal(t, expected, branch)
+		})
+	}
 }
 
 func TestEncodeJSONArrayOfObjects(t *testing.T) {
@@ -263,7 +272,13 @@ func TestEncodeJSONArrayOfObjects(t *testing.T) {
 			},
 		},
 	}
-	expected := `{
+	for _, testcase := range []struct {
+		compact  bool
+		expected string
+	}{
+		{
+			compact: false,
+			expected: `{
 	"foo": [
 		{
 			"foo": 3,
@@ -271,11 +286,21 @@ func TestEncodeJSONArrayOfObjects(t *testing.T) {
 		},
 		2
 	]
-}`
-	store := Store{}
-	out, err := store.EmitPlainFile(tree.Branches)
-	assert.Nil(t, err)
-	assert.Equal(t, expected, string(out))
+}`,
+		},
+		{
+			compact:  true,
+			expected: `{"foo":[{"foo":3,"bar":false},2]}`,
+		},
+	} {
+		t.Run(fmt.Sprintf("compact=%v", testcase.compact), func(t *testing.T) {
+			expected := testcase.expected
+			store := Store{Compact: testcase.compact}
+			out, err := store.EmitPlainFile(tree.Branches)
+			assert.Nil(t, err)
+			assert.Equal(t, expected, string(out))
+		})
+	}
 }
 
 func TestUnmarshalMetadataFromNonSOPSFile(t *testing.T) {
@@ -296,7 +321,11 @@ func TestLoadJSONFormattedBinaryFile(t *testing.T) {
 }
 
 func TestEmitValueString(t *testing.T) {
-	bytes, err := (&Store{}).EmitValue("hello")
-	assert.Nil(t, err)
-	assert.Equal(t, []byte("\"hello\""), bytes)
+	for _, compact := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compact=%v", compact), func(t *testing.T) {
+			bytes, err := (&Store{Compact: compact}).EmitValue("hello")
+			assert.Nil(t, err)
+			assert.Equal(t, []byte("\"hello\""), bytes)
+		})
+	}
 }


### PR DESCRIPTION
"compact-json" is json format without insignificant white space letters:

```
/workspace # sops -d --output-type json test.yaml
{
        "key1": "value1",
        "key2": {
                "nestedkey1": "value1",
                "nestedkey2": "value2"
        },
        "key3": [
                "value1",
                "value2",
                "value3"
        ]
}/workspace #
/workspace # sops -d --output-type compact-json test.yaml
{"key1":"value1","key2":{"nestedkey1":"value1","nestedkey2":"value2"},"key3":["value1","value2","value3"]}/workspace #
```

It would be nice if sops supports output with that format as values without line breaks are often useful to use in command parameters and values for environment variables.
