### PR TITLE
Fix exec-env with multiline env vars

### DIFF
--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -91,6 +91,7 @@ func ExecWithEnv(opts ExecOpts) {
 		if line[0] == '#' {
 			continue
 		}
+		line := bytes.Replace(line, []byte("\\n"), []byte("\n"), -1)
 		env = append(env, string(line))
 	}
 


### PR DESCRIPTION
When using the `exec-env` subcommand, SOPS does not unescape newline
characters. Causing the following behavior:

```console
$ echo 'FOO=foo\nbar\nbaz' > plaintext.env
$ sops -e --output ciphertext.env plaintext.env
$ sops exec-env ciphertext.env 'env | grep FOO | xxd'
00000000: 464f 4f3d 666f 6f5c 6e62 6172 5c6e 6261  FOO=foo\nbar\nba
00000010: 7a0a                                     z.
```

This commit unescapes the newlines when constructing the environment to
be passed to the given command, producing the expected output:

```console
$ sops exec-env ciphertext.env 'env | grep -A2 FOO | xxd'
00000000: 464f 4f3d 666f 6f0a 6261 720a 6261 7a0a  FOO=foo.bar.baz.
```