### PR TITLE
decrypt master key in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/fatih/color v1.7.0
 	github.com/golang/protobuf v1.3.2
+	github.com/google/go-cmp v0.3.0
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408
 	github.com/hashicorp/vault/api v1.0.4


### PR DESCRIPTION
Currently, Sops tries to decrypt the master key by iterating over each one in series. In practice, this can lead to significant performance issues if the working key is at the end of the list. The example case we encountered was using Sops with Ansible and the upcoming Sops plugin for it. During execution, Ansible calls sops for every task to decrypt the variables. In our case, we used KMS and PGP for our keys, and when running on a machine that relied on PGP, it would take over 30 seconds to decrypt a file as it iterated through providers. This would make PGP based builds take hours where it would take minutes for KMS based builds as it would fail the KMS key look up thousands of times throughout the run.

This change makes the decryption efforts happen in parallel, returning the first to succeed, making the speed faster than KMS based builds without affecting the KMS based build times.