### PR TITLE
Add support for decoding JSON arrays of arrays

### DIFF
--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -79,6 +79,12 @@ func (store Store) sliceFromJSONDecoder(dec *json.Decoder) ([]interface{}, error
 				return slice, err
 			}
 			slice = append(slice, item)
+		} else if ok && delim.String() == "[" {
+			item, err := store.sliceFromJSONDecoder(dec)
+			if err != nil {
+				return slice, err
+			}
+			slice = append(slice, item)
 		} else {
 			slice = append(slice, t)
 		}

--- a/stores/json/store_test.go
+++ b/stores/json/store_test.go
@@ -198,6 +198,31 @@ func TestDecodeJSONArrayOfObjects(t *testing.T) {
 	assert.Equal(t, expected, branch)
 }
 
+func TestDecodeJSONArrayOfArrays(t *testing.T) {
+	in := `{"foo": [[["foo", {"bar": "foo"}]]]}`
+	expected := sops.TreeBranch{
+		sops.TreeItem{
+			Key: "foo",
+			Value: []interface{}{
+				[]interface{}{
+					[]interface{}{
+						"foo",
+						sops.TreeBranch{
+							sops.TreeItem{
+								Key:   "bar",
+								Value: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	branch, err := Store{}.treeBranchFromJSON([]byte(in))
+	assert.Nil(t, err)
+	assert.Equal(t, expected, branch)
+}
+
 func TestEncodeSimpleJSON(t *testing.T) {
 	branch := sops.TreeBranch{
 		sops.TreeItem{


### PR DESCRIPTION
Add support for decoding JSON arrays of arrays by handling, during
slice decoding, when the next token is an array opening. This produces
nested []interface{} slices.

Closes #640.