### PR TITLE
Add a new YamlFile function to decrypt package that uses keyservices

### DIFF
--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -11,8 +11,72 @@ import (
 
 	"go.mozilla.org/sops/v3/aes"
 	"go.mozilla.org/sops/v3/cmd/sops/common"
-	. "go.mozilla.org/sops/v3/cmd/sops/formats" // Re-export
+	"go.mozilla.org/sops/v3/cmd/sops/formats"
+	"go.mozilla.org/sops/v3/keyservice"
+	"google.golang.org/grpc"
+	"gopkg.in/yaml.v2"
 )
+
+// YamlFile opens a sops encrypted yaml file, parses it into a struct
+// and returns an error if it fails. If a socket exists at /tmp/sops.sock,
+// it will be used as a keyservice.
+func YamlFile(path string, out interface{}) (err error) {
+	// Read the file into an []byte
+	encryptedData, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read file %q: %w", path, err)
+	}
+
+	var svcs []keyservice.KeyServiceClient
+	svcs = append(svcs, keyservice.NewLocalClient())
+	// try connecting to unix:///tmp/sops.sock
+	conn, err := grpc.Dial("unix:///tmp/sops.sock", []grpc.DialOption{grpc.WithInsecure()}...)
+	if err == nil {
+		// ignore errors but only add the keyservice if the dial call succeded
+		svcs = append(svcs, keyservice.NewKeyServiceClient(conn))
+	}
+
+	store := common.StoreForFormat(formats.Yaml)
+
+	// Load SOPS file and access the data key
+	tree, err := store.LoadEncryptedFile(encryptedData)
+	if err != nil {
+		return err
+	}
+	key, err := tree.Metadata.GetDataKeyWithKeyServices(svcs)
+	if err != nil {
+		return err
+	}
+
+	// Decrypt the tree
+	cipher := aes.NewCipher()
+	mac, err := tree.Decrypt(key, cipher)
+	if err != nil {
+		return err
+	}
+
+	// Compute the hash of the cleartext tree and compare it with
+	// the one that was stored in the document. If they match,
+	// integrity was preserved
+	originalMac, err := cipher.Decrypt(
+		tree.Metadata.MessageAuthenticationCode,
+		key,
+		tree.Metadata.LastModified.Format(time.RFC3339),
+	)
+	if originalMac != mac {
+		return fmt.Errorf("Failed to verify data integrity. expected mac %q, got %q", originalMac, mac)
+	}
+
+	cleartext, err := store.EmitPlainFile(tree.Branches)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt file: %w", err)
+	}
+	err = yaml.Unmarshal(cleartext, &out)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal cleartext into yaml: %w", err)
+	}
+	return nil
+}
 
 // File is a wrapper around Data that reads a local encrypted
 // file and returns its cleartext data in an []byte
@@ -24,13 +88,13 @@ func File(path, format string) (cleartext []byte, err error) {
 	}
 
 	// uses same logic as cli.
-	formatFmt := FormatForPathOrString(path, format)
+	formatFmt := formats.FormatForPathOrString(path, format)
 	return DataWithFormat(encryptedData, formatFmt)
 }
 
 // DataWithFormat is a helper that takes encrypted data, and a format enum value,
 // decrypts the data and returns its cleartext in an []byte.
-func DataWithFormat(data []byte, format Format) (cleartext []byte, err error) {
+func DataWithFormat(data []byte, format formats.Format) (cleartext []byte, err error) {
 
 	store := common.StoreForFormat(format)
 
@@ -71,6 +135,6 @@ func DataWithFormat(data []byte, format Format) (cleartext []byte, err error) {
 // The format string can be `json`, `yaml`, `ini`, `dotenv` or `binary`.
 // If the format string is empty, binary format is assumed.
 func Data(data []byte, format string) (cleartext []byte, err error) {
-	formatFmt := FormatFromString(format)
+	formatFmt := formats.FormatFromString(format)
 	return DataWithFormat(data, formatFmt)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/fatih/color v1.7.0
 	github.com/golang/protobuf v1.3.2
+	github.com/google/go-cmp v0.3.0
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408
 	github.com/hashicorp/vault/api v1.0.4
@@ -32,4 +33,5 @@ require (
 	google.golang.org/grpc v1.22.1
 	gopkg.in/ini.v1 v1.44.0
 	gopkg.in/urfave/cli.v1 v1.20.0
+	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
fixes #643

This doesn't break any existing code, it's just a new function in the decrypt package that makes a few assumptions, like the presence of a keyservice unix socket at /tmp/sops.sock.

Perhaps we could call this WorkspaceYamlFile so it's clear it's specific to us?