### PR TITLE
Add support for omiting filename in Vault path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -967,6 +967,7 @@ This command requires a ``.sops.yaml`` configuration file. Below is an example:
       - vault_path: "sops/"
         vault_kv_mount_name: "secret/" # default
         vault_kv_version: 2 # default
+        vault_path_omit_filename: false # default
         path_regex: vault/*
         omit_extensions: true
 
@@ -988,7 +989,7 @@ Publishing to Vault
 
 There are a few settings for Vault that you can place in your destination rules. The first
 is ``vault_path``, which is required. The others are optional, and they are
-``vault_address``, ``vault_kv_mount_name``, ``vault_kv_version``.
+``vault_address``, ``vault_kv_mount_name``, ``vault_kv_version``, ``vault_path_omit_filename``.
 
 ``sops`` uses the official Vault API provided by Hashicorp, which makes use of `environment
 variables <https://www.vaultproject.io/docs/commands/#environment-variables>`_ for
@@ -996,6 +997,7 @@ configuring the client.
 
 ``vault_kv_mount_name`` is used if your Vault KV is mounted somewhere other than ``secret/``.
 ``vault_kv_version`` supports ``1`` and ``2``, with ``2`` being the default.
+``vault_path_omit_filename`` set to ``true`` to omit filename from Vault path. ``false`` by default.
 
 If destination secret path already exists in Vault and contains same data as the source file, it
 will be skipped.

--- a/config/config.go
+++ b/config/config.go
@@ -90,17 +90,18 @@ type azureKVKey struct {
 }
 
 type destinationRule struct {
-	PathRegex        string       `yaml:"path_regex"`
-	S3Bucket         string       `yaml:"s3_bucket"`
-	S3Prefix         string       `yaml:"s3_prefix"`
-	GCSBucket        string       `yaml:"gcs_bucket"`
-	GCSPrefix        string       `yaml:"gcs_prefix"`
-	VaultPath        string       `yaml:"vault_path"`
-	VaultAddress     string       `yaml:"vault_address"`
-	VaultKVMountName string       `yaml:"vault_kv_mount_name"`
-	VaultKVVersion   int          `yaml:"vault_kv_version"`
-	RecreationRule   creationRule `yaml:"recreation_rule,omitempty"`
-	OmitExtensions   bool         `yaml:"omit_extensions"`
+	PathRegex             string       `yaml:"path_regex"`
+	S3Bucket              string       `yaml:"s3_bucket"`
+	S3Prefix              string       `yaml:"s3_prefix"`
+	GCSBucket             string       `yaml:"gcs_bucket"`
+	GCSPrefix             string       `yaml:"gcs_prefix"`
+	VaultPath             string       `yaml:"vault_path"`
+	VaultAddress          string       `yaml:"vault_address"`
+	VaultKVMountName      string       `yaml:"vault_kv_mount_name"`
+	VaultKVVersion        int          `yaml:"vault_kv_version"`
+	VaultPathOmitFilename bool         `yaml:"vault_path_omit_filename"`
+	RecreationRule        creationRule `yaml:"recreation_rule,omitempty"`
+	OmitExtensions        bool         `yaml:"omit_extensions"`
 }
 
 type creationRule struct {
@@ -259,7 +260,7 @@ func parseDestinationRuleForFile(conf *configFile, filePath string, kmsEncryptio
 			dest = publish.NewGCSDestination(dRule.GCSBucket, dRule.GCSPrefix)
 		}
 		if dRule.VaultPath != "" {
-			dest = publish.NewVaultDestination(dRule.VaultAddress, dRule.VaultPath, dRule.VaultKVMountName, dRule.VaultKVVersion)
+			dest = publish.NewVaultDestination(dRule.VaultAddress, dRule.VaultPath, dRule.VaultKVMountName, dRule.VaultKVVersion, dRule.VaultPathOmitFilename)
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -178,6 +178,9 @@ destination_rules:
     vault_kv_mount_name: "kv/"
     vault_kv_version: 1
     path_regex: "vault-v1/*"
+  - vault_path: "omit/"
+    vault_path_omit_filename: true
+    path_regex: "vault-omit-filename/*"
 `)
 
 func parseConfigFile(confBytes []byte, t *testing.T) *configFile {
@@ -328,4 +331,8 @@ func TestLoadConfigFileWithVaultDestinationRules(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, conf.Destination)
 	assert.Equal(t, "http://127.0.0.1:8200/v1/kv/barfoo/barfoo", conf.Destination.Path("barfoo"))
+	conf, err = parseDestinationRuleForFile(parseConfigFile(sampleConfigWithVaultDestinationRules, t), "vault-omit-filename/barfoo", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, conf.Destination)
+	assert.Equal(t, "http://127.0.0.1:8200/v1/secret/data/omit/", conf.Destination.Path("omit"))
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/fatih/color v1.7.0
 	github.com/golang/protobuf v1.3.2
+	github.com/google/go-cmp v0.3.0
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408
 	github.com/hashicorp/vault/api v1.0.4

--- a/publish/vault.go
+++ b/publish/vault.go
@@ -18,13 +18,14 @@ func init() {
 }
 
 type VaultDestination struct {
-	vaultAddress string
-	vaultPath    string
-	kvMountName  string
-	kvVersion    int
+	vaultAddress          string
+	vaultPath             string
+	kvMountName           string
+	kvVersion             int
+	vaultPathOmitFilename bool
 }
 
-func NewVaultDestination(vaultAddress, vaultPath, kvMountName string, kvVersion int) *VaultDestination {
+func NewVaultDestination(vaultAddress, vaultPath, kvMountName string, kvVersion int, vaultPathOmitFilename bool) *VaultDestination {
 	if !strings.HasSuffix(vaultPath, "/") {
 		vaultPath = vaultPath + "/"
 	}
@@ -37,7 +38,7 @@ func NewVaultDestination(vaultAddress, vaultPath, kvMountName string, kvVersion 
 	if kvVersion != 1 && kvVersion != 2 {
 		kvVersion = 2
 	}
-	return &VaultDestination{vaultAddress, vaultPath, kvMountName, kvVersion}
+	return &VaultDestination{vaultAddress, vaultPath, kvMountName, kvVersion, vaultPathOmitFilename}
 }
 
 func (vaultd *VaultDestination) getAddress() string {
@@ -52,6 +53,9 @@ func (vaultd *VaultDestination) Path(fileName string) string {
 }
 
 func (vaultd *VaultDestination) secretsPath(fileName string) string {
+	if vaultd.vaultPathOmitFilename {
+		fileName = ""
+	}
 	if vaultd.kvVersion == 1 {
 		return fmt.Sprintf("%s%s%s", vaultd.kvMountName, vaultd.vaultPath, fileName)
 	}


### PR DESCRIPTION
Adds a new setting into Vault's destination rule called `vault_path_omit_filename` which is false by default so there is no breaking change. And if it's set to true it will omit filename in Vault path.

Closes #659