### PR TITLE
Fix #611 - Dont break when config file exists but CreationRules are empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -274,6 +274,11 @@ func parseDestinationRuleForFile(conf *configFile, filePath string, kmsEncryptio
 }
 
 func parseCreationRuleForFile(conf *configFile, filePath string, kmsEncryptionContext map[string]*string) (*Config, error) {
+	// If config file doesn't contain CreationRules (it's empty or only contains DestionationRules), assume it does not exist
+	if conf.CreationRules == nil {
+		return nil, nil
+	}
+
 	var rule *creationRule
 
 	for _, r := range conf.CreationRules {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -139,8 +139,25 @@ creation_rules:
     encrypted_suffix: _enc
     `)
 
-var sampleInvalidConfig = []byte(`
+var sampleConfigWithNoMatchingRules = []byte(`
 creation_rules:
+  - path_regex: notexisting
+    pgp: bar
+`)
+
+var sampleEmptyConfig = []byte(``)
+
+var sampleConfigWithEmptyCreationRules = []byte(`
+creation_rules:
+`)
+
+var sampleConfigWithOnlyDestinationRules = []byte(`
+destination_rules:
+  - path_regex: ""
+    s3_bucket: "foobar"
+    s3_prefix: "test/"
+    recreation_rule:
+      pgp: newpgp
 `)
 
 var sampleConfigWithDestinationRule = []byte(`
@@ -248,9 +265,27 @@ func TestLoadConfigFileWithGroups(t *testing.T) {
 	assert.Equal(t, expected, conf)
 }
 
-func TestLoadInvalidConfigFile(t *testing.T) {
-	_, err := parseCreationRuleForFile(parseConfigFile(sampleInvalidConfig, t), "foobar2000", nil)
+func TestLoadConfigFileWithNoMatchingRules(t *testing.T) {
+	_, err := parseCreationRuleForFile(parseConfigFile(sampleConfigWithNoMatchingRules, t), "foobar2000", nil)
 	assert.NotNil(t, err)
+}
+
+func TestLoadEmptyConfigFile(t *testing.T) {
+	conf, err := parseCreationRuleForFile(parseConfigFile(sampleEmptyConfig, t), "foobar2000", nil)
+	assert.Nil(t, conf)
+	assert.Nil(t, err)
+}
+
+func TestLoadConfigFileWithEmptyCreationRules(t *testing.T) {
+	conf, err := parseCreationRuleForFile(parseConfigFile(sampleConfigWithEmptyCreationRules, t), "foobar2000", nil)
+	assert.Nil(t, conf)
+	assert.Nil(t, err)
+}
+
+func TestLoadConfigFileWithOnlyDestinationRules(t *testing.T) {
+	conf, err := parseCreationRuleForFile(parseConfigFile(sampleConfigWithOnlyDestinationRules, t), "foobar2000", nil)
+	assert.Nil(t, conf)
+	assert.Nil(t, err)
 }
 
 func TestKeyGroupsForFile(t *testing.T) {


### PR DESCRIPTION
This fixes couple of similar issues, one of them a real use-case.

Currently SOPS breaks if .sops.yaml:
- exists but is empty
- contains `creation_rules:` with no defined rules
- contains only `DestinationRules` but no `CreationRules`
- contains no matching `CreationRules`
- contains invalid  `CreationRules`

It should only break in 4th and 5th case. First 3 cases should be treated as if no .sops.yaml was provided. It's best demonstrated by 3rd case when we want to provide KMS/GPG via CLI argument but we want to have `.sops.yaml` file with `DestionationRule` to publish secrets to Vault. This is currently not possible and is fixed in this PR. 

I added tests for all 4 cases. 5th already has a proper test.

Closes #611