### PR TITLE
Not finding a matching creation rule is not an error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -279,23 +279,19 @@ func parseCreationRuleForFile(conf *configFile, filePath string, kmsEncryptionCo
 		return nil, nil
 	}
 
-	var rule *creationRule
+	var rule creationRule
 
 	for _, r := range conf.CreationRules {
 		if r.PathRegex == "" {
-			rule = &r
+			rule = r
 			break
 		}
 		if r.PathRegex != "" {
 			if match, _ := regexp.MatchString(r.PathRegex, filePath); match {
-				rule = &r
+				rule = r
 				break
 			}
 		}
-	}
-
-	if rule == nil {
-		return nil, fmt.Errorf("error loading config: no matching creation rules found")
 	}
 
 	config, err := configFromRule(rule, kmsEncryptionContext)


### PR DESCRIPTION
This is probably broken in many subtle ways. I'd have to think about it more.