### PR TITLE
Fix #671: `updatekeys` checks for config file flag

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -477,8 +477,8 @@ func main() {
 				var err error
 				var configPath string
 				// Check if config is provided though the command line
-				if c.String("config") != "" {
-					configPath = c.String("config")
+				if c.GlobalString("config") != "" {
+					configPath = c.GlobalString("config")
 				} else {
 					configPath, err = config.FindConfigFile(".")
 					if err != nil {

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -474,9 +474,15 @@ func main() {
 				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
-				configPath, err := config.FindConfigFile(".")
-				if err != nil {
-					return common.NewExitError(err, codes.ErrorGeneric)
+				var err error
+				var configPath string
+				if c.String("config") != "" {
+					configPath = c.String("config")
+				} else {
+					configPath, err = config.FindConfigFile(".")
+					if err != nil {
+						return common.NewExitError(err, codes.ErrorGeneric)
+					}
 				}
 				if c.NArg() < 1 {
 					return common.NewExitError("Error: no file specified", codes.NoFileSpecified)

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -476,7 +476,6 @@ func main() {
 			Action: func(c *cli.Context) error {
 				var err error
 				var configPath string
-				// Check if config is provided though the command line
 				if c.GlobalString("config") != "" {
 					configPath = c.GlobalString("config")
 				} else {

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -476,6 +476,7 @@ func main() {
 			Action: func(c *cli.Context) error {
 				var err error
 				var configPath string
+				// Check if config is provided though the command line
 				if c.String("config") != "" {
 					configPath = c.String("config")
 				} else {


### PR DESCRIPTION
The 'updatekeys' subcommand did not check for the config global string flag.
 Add that check and if found use it to set configPath.