### PR TITLE
AWS Profile not correctly resolving .aws/config file - #679

### DIFF
--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -195,13 +195,11 @@ func (key MasterKey) createSession() (*session.Session, error) {
 
 	config := aws.Config{Region: aws.String(matches[1])}
 
-	if key.AwsProfile != "" {
-		config.Credentials = credentials.NewSharedCredentials("", key.AwsProfile)
-	}
-
 	opts := session.Options{
+		Profile:                 key.AwsProfile,
 		Config:                  config,
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+		SharedConfigState:       session.SharedConfigEnable,
 	}
 	sess, err := session.NewSessionWithOptions(opts)
 	if err != nil {


### PR DESCRIPTION
Possible fix for issue #679 . After building, I am successfully able to run the following:

```bash
# Can read the profile in the sops file from .aws/config
sops my-secrets.yaml
# If profile is not in the sops file, can still set AWS_PROFILE directly
AWS_PROFILE=my-account sops my-secrets.yaml

# If profile is set in BOTH env and the sops file, the sops file still takes priority to avoid breaking change.
# Here AWS_PROFILE is ignored if profile is defined in my-secrets.yaml
AWS_PROFILE=my-account sops my-secrets.yaml
```