### PR TITLE
updatekeys: Make file path absolute

### DIFF
--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -34,6 +34,7 @@ func UpdateKeys(opts Opts) error {
 	if info.IsDir() {
 		return fmt.Errorf("can't operate on a directory")
 	}
+	opts.InputPath = path
 	return updateFile(opts)
 }
 


### PR DESCRIPTION
"sops updatekeys" is not working the same as when encrypting a file. The
reason is that for "sops --encrypt", the file path is made absolute before
it is compared with the path_regex in the config file. This is not done for
"sops updatekeys", therefore it does not match the correct entry in the
config file when updating keys.