### PR TITLE
Close tmpfile after writing

### DIFF
--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -134,7 +134,7 @@ func editTree(opts editOpts, tree *sops.Tree, dataKey []byte) ([]byte, error) {
 	}
 	
 	// Close temporary file, since Windows won't delete the file unless it's closed beforehand
-	tmpfile.Close()
+	defer tmpfile.Close()
 
 	// Compute file hash to detect if the file has been edited
 	origHash, err := hashFile(tmpfile.Name())

--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -133,7 +133,7 @@ func editTree(opts editOpts, tree *sops.Tree, dataKey []byte) ([]byte, error) {
 		return nil, common.NewExitError(fmt.Sprintf("Could not write output file: %s", err), codes.CouldNotWriteOutputFile)
 	}
 	
-	// Close temporary file to placate Windows Delete call
+	// Close temporary file, since Windows won't delete the file unless it's closed beforehand
 	tmpfile.Close()
 
 	// Compute file hash to detect if the file has been edited

--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -132,6 +132,9 @@ func editTree(opts editOpts, tree *sops.Tree, dataKey []byte) ([]byte, error) {
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Could not write output file: %s", err), codes.CouldNotWriteOutputFile)
 	}
+	
+	// Close temporary file to placate Windows Delete call
+	tmpfile.Close()
 
 	// Compute file hash to detect if the file has been edited
 	origHash, err := hashFile(tmpfile.Name())


### PR DESCRIPTION
This PR closes https://github.com/mozilla/sops/issues/624

Windows will not allow for deletion of a file that has an open handle. 

Close tmpfile after writing to prevent unencrypted tmpfiles out-living
the execution of sops.