### PR TITLE
Fix endless loop in x/crypto/openpgp func ReadMessage

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -372,9 +372,9 @@ func TestLoadConfigFileWithVaultDestinationRules(t *testing.T) {
 	conf, err := parseDestinationRuleForFile(parseConfigFile(sampleConfigWithVaultDestinationRules, t), "vault-v2/barfoo", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, conf.Destination)
-	assert.Equal(t, "http://127.0.0.1:8200/v1/secret/data/foobar/barfoo", conf.Destination.Path("barfoo"))
+	assert.Equal(t, "https://127.0.0.1:8200/v1/secret/data/foobar/barfoo", conf.Destination.Path("barfoo"))
 	conf, err = parseDestinationRuleForFile(parseConfigFile(sampleConfigWithVaultDestinationRules, t), "vault-v1/barfoo", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, conf.Destination)
-	assert.Equal(t, "http://127.0.0.1:8200/v1/kv/barfoo/barfoo", conf.Destination.Path("barfoo"))
+	assert.Equal(t, "https://127.0.0.1:8200/v1/kv/barfoo/barfoo", conf.Destination.Path("barfoo"))
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -372,9 +372,9 @@ func TestLoadConfigFileWithVaultDestinationRules(t *testing.T) {
 	conf, err := parseDestinationRuleForFile(parseConfigFile(sampleConfigWithVaultDestinationRules, t), "vault-v2/barfoo", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, conf.Destination)
-	assert.Equal(t, "https://127.0.0.1:8200/v1/secret/data/foobar/barfoo", conf.Destination.Path("barfoo"))
+	assert.Equal(t, "http://127.0.0.1:8200/v1/secret/data/foobar/barfoo", conf.Destination.Path("barfoo"))
 	conf, err = parseDestinationRuleForFile(parseConfigFile(sampleConfigWithVaultDestinationRules, t), "vault-v1/barfoo", nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, conf.Destination)
-	assert.Equal(t, "https://127.0.0.1:8200/v1/kv/barfoo/barfoo", conf.Destination.Path("barfoo"))
+	assert.Equal(t, "http://127.0.0.1:8200/v1/kv/barfoo/barfoo", conf.Destination.Path("barfoo"))
 }

--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -323,7 +323,7 @@ func (key *MasterKey) passphrasePrompt() func(keys []openpgp.Key, symmetric bool
 	maxCalls := 3
 	return func(keys []openpgp.Key, symmetric bool) ([]byte, error) {
 		if callCounter >= maxCalls {
-			return nil, fmt.Errorf("function passphrasePrompt called more than once")
+			return nil, fmt.Errorf("function passphrasePrompt called too many times")
 		}
 		callCounter++
 

--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -216,7 +216,7 @@ func (key *MasterKey) decryptWithCryptoOpenpgp() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Armor decoding failed: %s", err)
 	}
-	md, err := openpgp.ReadMessage(block.Body, ring, key.passphrasePrompt, nil)
+	md, err := openpgp.ReadMessage(block.Body, ring, key.passphrasePrompt(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("Reading PGP message failed: %s", err)
 	}
@@ -318,39 +318,48 @@ func (key *MasterKey) fingerprintMap(ring openpgp.EntityList) map[string]openpgp
 	return fps
 }
 
-func (key *MasterKey) passphrasePrompt(keys []openpgp.Key, symmetric bool) ([]byte, error) {
-	conn, err := gpgagent.NewConn()
-	if err == gpgagent.ErrNoAgent {
-		log.Infof("gpg-agent not found, continuing with manual passphrase " +
-			"input...")
-		fmt.Print("Enter PGP key passphrase: ")
-		pass, err := gopass.GetPasswd()
-		if err != nil {
-			return nil, err
+func (key *MasterKey) passphrasePrompt() func(keys []openpgp.Key, symmetric bool) ([]byte, error) {
+	callCounter := 0
+	maxCalls := 3
+	return func(keys []openpgp.Key, symmetric bool) ([]byte, error) {
+		if callCounter >= maxCalls {
+			return nil, fmt.Errorf("function passphrasePrompt called more than once")
 		}
+		callCounter++
+
+		conn, err := gpgagent.NewConn()
+		if err == gpgagent.ErrNoAgent {
+			log.Infof("gpg-agent not found, continuing with manual passphrase " +
+				"input...")
+			fmt.Print("Enter PGP key passphrase: ")
+			pass, err := gopass.GetPasswd()
+			if err != nil {
+				return nil, err
+			}
+			for _, k := range keys {
+				k.PrivateKey.Decrypt(pass)
+			}
+			return pass, err
+		}
+		if err != nil {
+			return nil, fmt.Errorf("Could not establish connection with gpg-agent: %s", err)
+		}
+		defer conn.Close()
 		for _, k := range keys {
-			k.PrivateKey.Decrypt(pass)
+			req := gpgagent.PassphraseRequest{
+				CacheKey: k.PublicKey.KeyIdShortString(),
+				Prompt:   "Passphrase",
+				Desc:     fmt.Sprintf("Unlock key %s to decrypt sops's key", k.PublicKey.KeyIdShortString()),
+			}
+			pass, err := conn.GetPassphrase(&req)
+			if err != nil {
+				return nil, fmt.Errorf("gpg-agent passphrase request errored: %s", err)
+			}
+			k.PrivateKey.Decrypt([]byte(pass))
+			return []byte(pass), nil
 		}
-		return pass, err
+		return nil, fmt.Errorf("No key to unlock")
 	}
-	if err != nil {
-		return nil, fmt.Errorf("Could not establish connection with gpg-agent: %s", err)
-	}
-	defer conn.Close()
-	for _, k := range keys {
-		req := gpgagent.PassphraseRequest{
-			CacheKey: k.PublicKey.KeyIdShortString(),
-			Prompt:   "Passphrase",
-			Desc:     fmt.Sprintf("Unlock key %s to decrypt sops's key", k.PublicKey.KeyIdShortString()),
-		}
-		pass, err := conn.GetPassphrase(&req)
-		if err != nil {
-			return nil, fmt.Errorf("gpg-agent passphrase request errored: %s", err)
-		}
-		k.PrivateKey.Decrypt([]byte(pass))
-		return []byte(pass), nil
-	}
-	return nil, fmt.Errorf("No key to unlock")
 }
 
 // ToMap converts the MasterKey into a map for serialization purposes


### PR DESCRIPTION
I wasn't able to write tests for it, because for this problem to occur, I had to produce a slightly inconsistent state 
with private keys. I guess this only occurs if some old private key (GPG 1?) are migrated to GPG 2.
But this is only guessing.

Nevertheless I was able to test it locally with my GPG key, which produced this problem, before I fixed it.
