### PR TITLE
Support --input-type for exec-file

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -190,7 +190,7 @@ func main() {
                                 },
 				cli.StringFlag{
 					Name:  "output-type",
-					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the binary output format",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
 				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -184,6 +184,10 @@ func main() {
 					Name:  "user",
 					Usage: "the user to run the command as",
 				},
+				cli.StringFlag{
+                                        Name:  "input-type",
+                                        Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the file's extension to determine the type",
+                                },
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
@@ -966,8 +970,9 @@ func inputStore(context *cli.Context, path string) common.Store {
 	return common.DefaultStoreForPathOrFormat(path, context.String("input-type"))
 }
 
+// SCARY! SHOULD THIS BE USING INPUT-TYPE?
 func outputStore(context *cli.Context, path string) common.Store {
-	return common.DefaultStoreForPathOrFormat(path, context.String("output-type"))
+	return common.DefaultStoreForPathOrFormat(path, context.String("input-type"))
 }
 
 func parseTreePath(arg string) ([]interface{}, error) {

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -188,6 +188,10 @@ func main() {
                                         Name:  "input-type",
                                         Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the file's extension to determine the type",
                                 },
+				cli.StringFlag{
+					Name:  "output-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the binary output format",
+				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
@@ -970,9 +974,8 @@ func inputStore(context *cli.Context, path string) common.Store {
 	return common.DefaultStoreForPathOrFormat(path, context.String("input-type"))
 }
 
-// SCARY! SHOULD THIS BE USING INPUT-TYPE?
 func outputStore(context *cli.Context, path string) common.Store {
-	return common.DefaultStoreForPathOrFormat(path, context.String("input-type"))
+	return common.DefaultStoreForPathOrFormat(path, context.String("output-type"))
 }
 
 func parseTreePath(arg string) ([]interface{}, error) {


### PR DESCRIPTION
This PR resolves https://github.com/mozilla/sops/issues/652, adding support for an `--input-type` argument that will be honored by `sops exec-file`.

Until the argument for `func outputStore` was reversed (to use `input-type` instead of `output-type`) sops kept crashing with the message: 

> Error dumping file: No binary data found in tree

This is certainly a debatable fix, but results were positive.