### PR TITLE
one line fix for install in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ For the adventurous, unstable features are available in the `develop` branch, wh
 .. code:: bash
 
 	$ go get -u go.mozilla.org/sops/v3/cmd/sops
-        $ cd $GOPATH/src/go.mozilla.org/sops/
+        $ cd $GOPATH/src/go.mozilla.org/sops/v3
         $ git checkout develop
         $ make install
 


### PR DESCRIPTION
To do the `git checkout development` you need to be one extra level deep in the hierarchy. 