### PR TITLE
Switch gpg.mozilla.org out for keys.openpgp.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -673,10 +673,9 @@ Example: place the following in your ``~/.bashrc``
 Specify a different GPG key server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, ``sops`` uses the key server ``gpg.mozilla.org`` to retrieve the GPG
+By default, ``sops`` uses the key server ``keys.openpgp.org`` to retrieve the GPG
 keys that are not present in the local keyring.
-To use a different GPG key server, set the ``SOPS_GPG_KEYSERVER`` environment
-variable.
+This is no longer configurable. You can learn more about why from this write-up: [SKS Keyserver Network Under Attack](https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f).
 
 Example: place the following in your ``~/.bashrc``
 

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -109,7 +109,6 @@ func main() {
    the "add-{kms,pgp,gcp-kms,azure-kv,hc-vault-transit}" and "rm-{kms,pgp,gcp-kms,azure-kv,hc-vault-transit}" flags.
 
    To use a different GPG binary than the one in your PATH, set SOPS_GPG_EXEC.
-   To use a GPG key server other than gpg.mozilla.org, set SOPS_GPG_KEYSERVER.
 
    To select a different editor than the default (vim), set EDITOR.
 
@@ -185,9 +184,9 @@ func main() {
 					Usage: "the user to run the command as",
 				},
 				cli.StringFlag{
-                                        Name:  "input-type",
-                                        Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the file's extension to determine the type",
-                                },
+					Name:  "input-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the file's extension to determine the type",
+				},
 				cli.StringFlag{
 					Name:  "output-type",
 					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",

--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -45,6 +45,6 @@ func TestPGPKeySourceFromString(t *testing.T) {
 
 func TestRetrievePGPKey(t *testing.T) {
 	fingerprint := "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
-	_, err := getKeyFromKeyServer("gpg.mozilla.org", fingerprint)
+	_, err := getKeyFromKeyServer(fingerprint)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
* Make use of keys.openpgp.org
* No longer allow for configuring a different keyserver.

Short-term fix for #727 and currently broken builds. 