### PR TITLE
add filename to exec-file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1013,6 +1013,9 @@ encrypted file is only readable by root, but the target program does not
 need root privileges to function. This flag should be used where possible
 for added security.
 
+To overwrite the default file name (``tmp-file``) in ``exec-file`` use the
+``--filename <filename>`` parameter.
+
 .. code:: bash
 
    # the encrypted file can't be read by the current user

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -132,6 +132,11 @@ func main() {
 					Name:  "user",
 					Usage: "the user to run the command as",
 				},
+				cli.StringFlag{
+					Name:  "filename",
+					Usage: "filename for the temporarily file (default: tmp-file)",
+				},
+
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
@@ -222,12 +227,18 @@ func main() {
 					return toExitError(err)
 				}
 
+				filename := c.String("filename")
+				if filename == "" {
+					filename = "tmp-file"
+				}
+
 				if err := exec.ExecWithFile(exec.ExecOpts{
 					Command:    command,
 					Plaintext:  output,
 					Background: c.Bool("background"),
 					Fifo:       !c.Bool("no-fifo"),
 					User:       c.String("user"),
+					Filename:   c.String("filename"),
 				}); err != nil {
 					return toExitError(err)
 				}

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -132,11 +132,6 @@ func main() {
 					Name:  "user",
 					Usage: "the user to run the command as",
 				},
-				cli.StringFlag{
-					Name:  "filename",
-					Usage: "filename for the temporarily file (default: tmp-file)",
-				},
-
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
@@ -200,6 +195,10 @@ func main() {
 					Name:  "output-type",
 					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
 				},
+				cli.StringFlag{
+					Name:  "filename",
+					Usage: "filename for the temporarily file (default: tmp-file)",
+				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
@@ -238,7 +237,7 @@ func main() {
 					Background: c.Bool("background"),
 					Fifo:       !c.Bool("no-fifo"),
 					User:       c.String("user"),
-					Filename:   c.String("filename"),
+					Filename:   filename,
 				}); err != nil {
 					return toExitError(err)
 				}

--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -24,10 +24,11 @@ type ExecOpts struct {
 	Background bool
 	Fifo       bool
 	User       string
+	Filename   string
 }
 
-func GetFile(dir string) *os.File {
-	handle, err := ioutil.TempFile(dir, "tmp-file")
+func GetFile(dir, filename string) *os.File {
+	handle, err := ioutil.TempFile(dir, filename)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -54,10 +55,10 @@ func ExecWithFile(opts ExecOpts) error {
 	if opts.Fifo {
 		// fifo handling needs to be async, even opening to write
 		// will block if there is no reader present
-		filename = GetPipe(dir)
+		filename = GetPipe(dir, opts.Filename)
 		go WritePipe(filename, opts.Plaintext)
 	} else {
-		handle := GetFile(dir)
+		handle := GetFile(dir, opts.Filename)
 		handle.Write(opts.Plaintext)
 		handle.Close()
 		filename = handle.Name()

--- a/cmd/sops/subcommand/exec/exec_unix.go
+++ b/cmd/sops/subcommand/exec/exec_unix.go
@@ -27,8 +27,8 @@ func WritePipe(pipe string, contents []byte) {
 	handle.Close()
 }
 
-func GetPipe(dir string) string {
-	tmpfn := filepath.Join(dir, "tmp-file")
+func GetPipe(dir, filename string) string {
+	tmpfn := filepath.Join(dir, filename)
 	err := syscall.Mkfifo(tmpfn, 0600)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/sops/subcommand/exec/exec_windows.go
+++ b/cmd/sops/subcommand/exec/exec_windows.go
@@ -12,7 +12,7 @@ func WritePipe(pipe string, contents []byte) {
 	log.Fatal("fifos are not available on windows")
 }
 
-func GetPipe(dir string) string {
+func GetPipe(dir, filename string) string {
 	log.Fatal("fifos are not available on windows")
 	return ""
 }


### PR DESCRIPTION
Some tools (e.g. Terraform) require the right file extension to recognize the file type.

see more details for terraform at https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files

i get this error
```sh
~/.go/bin/sops exec-file test.json "terraform plan -var-file={}"

Error: Argument or block definition required

  on /tmp/.sops640510710/tmp-file line 1:
   1: {

An argument or block definition is required here.

exit status 1
```
works for me:
```sh
~/.go/bin/sops exec-file --filename test.json test.json "terraform plan -var-file={}"

Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.
...
```