### PR TITLE
Remove dead broken code

### DIFF
--- a/stores/ini/store.go
+++ b/stores/ini/store.go
@@ -252,56 +252,6 @@ func (store *Store) encodeMetadataToIniBranch(md stores.Metadata) (sops.TreeBran
 	return branch, nil
 }
 
-func encodeMetadataItem(prefix string, kind reflect.Kind, field reflect.Value) (map[string]interface{}, error) {
-
-	result := make(map[string]interface{}, 0)
-
-	switch kind {
-	case reflect.Slice:
-		slf := field
-		for j := 0; j < slf.Len(); j++ {
-			item := slf.Index(j)
-			p := fmt.Sprintf("%s[%d]", prefix, j)
-			r, err := encodeMetadataItem(p, item.Type().Kind(), item)
-			if err != nil {
-				return result, err
-			}
-			for k, v := range r {
-				result[k] = v
-			}
-		}
-	case reflect.Struct:
-		for i := 0; i < field.NumField(); i++ {
-			sf := field.Type().Field(i)
-			var name string
-			if prefix == "" {
-				name = sf.Name
-			} else {
-				name = fmt.Sprintf("%s.%s", prefix, sf.Name)
-			}
-			r, err := encodeMetadataItem(name, sf.Type.Kind(), field.Field(i))
-			if err != nil {
-				return result, err
-			}
-			for k, v := range r {
-				result[k] = v
-			}
-		}
-	case reflect.Int:
-		if field.Int() != 0 {
-			result[prefix] = string(field.Int())
-		}
-	case reflect.String:
-		if field.String() != "" {
-			result[prefix] = strings.Replace(field.String(), "\n", "\\n", -1)
-		}
-	default:
-		return result, fmt.Errorf("Cannot encode %s, unexpected type %s", prefix, kind)
-	}
-
-	return result, nil
-}
-
 // EmitPlainFile returns the plaintext INI file bytes corresponding to a sops.TreeBranches object
 func (store *Store) EmitPlainFile(in sops.TreeBranches) ([]byte, error) {
 	out, err := store.iniFromTreeBranches(in)

--- a/stores/ini/store.go
+++ b/stores/ini/store.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"reflect"
 	"strconv"
 	"strings"
 


### PR DESCRIPTION
The function `encodeMetadataItem` in stores/ini/store.go is not used anywhere, and fails compilation (see #774).

The failure might be Go version dependent (my `go version` says `go version go1.15.6 linux/amd64`), but since the code isn't used, I guess it's best to just remove it.