### PR TITLE
Issue 805 - support govcloud role in kms+role format

### DIFF
--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -135,7 +135,7 @@ func NewMasterKey(arn string, role string, context map[string]*string) *MasterKe
 func NewMasterKeyFromArn(arn string, context map[string]*string, awsProfile string) *MasterKey {
 	k := &MasterKey{}
 	arn = strings.Replace(arn, " ", "", -1)
-	roleIndex := strings.Index(arn, "+arn:aws:iam::")
+	roleIndex := strings.Index(arn, "+arn:aws")
 	if roleIndex > 0 {
 		k.Arn = arn[:roleIndex]
 		k.Role = arn[roleIndex+1:]


### PR DESCRIPTION
AWS supports partitions other than "aws" and not sure we really care the format of the role beyond the +, but didnt want to go that far with the change.  If the role isnt correct, the encryption will fail whether its a typo or some other reason.
