### PR TITLE
Add wrap verb to formatted error outputs

### DIFF
--- a/age/keysource.go
+++ b/age/keysource.go
@@ -48,17 +48,17 @@ func (key *MasterKey) Encrypt(datakey []byte) error {
 
 	w, err := age.Encrypt(buffer, key.parsedRecipient)
 	if err != nil {
-		return fmt.Errorf("failed to open file for encrypting sops data key with age: %v", err)
+		return fmt.Errorf("failed to open file for encrypting sops data key with age: %w", err)
 	}
 
 	if _, err := w.Write(datakey); err != nil {
 		log.WithField("recipient", key.parsedRecipient).Error("Encryption failed")
-		return fmt.Errorf("failed to encrypt sops data key with age: %v", err)
+		return fmt.Errorf("failed to encrypt sops data key with age: %w", err)
 	}
 
 	if err := w.Close(); err != nil {
 		log.WithField("recipient", key.parsedRecipient).Error("Encryption failed")
-		return fmt.Errorf("failed to close file for encrypting sops data key with age: %v", err)
+		return fmt.Errorf("failed to close file for encrypting sops data key with age: %w", err)
 	}
 
 	key.EncryptedKey = buffer.String()
@@ -95,7 +95,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 		userConfigDir, err := os.UserConfigDir()
 
 		if err != nil {
-			return nil, fmt.Errorf("user config directory could not be determined: %v", err)
+			return nil, fmt.Errorf("user config directory could not be determined: %w", err)
 		}
 
 		ageKeyFilePath = filepath.Join(userConfigDir, "sops", "age", "keys.txt")
@@ -104,7 +104,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	ageKeyFile, err := os.Open(ageKeyFilePath)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %v", err)
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 
 	defer ageKeyFile.Close()
@@ -188,7 +188,7 @@ func parseRecipient(recipient string) (*age.X25519Recipient, error) {
 	parsedRecipient, err := age.ParseX25519Recipient(recipient)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse input as Bech32-encoded age public key: %v", err)
+		return nil, fmt.Errorf("failed to parse input as Bech32-encoded age public key: %w", err)
 	}
 
 	return parsedRecipient, nil

--- a/azkv/keysource.go
+++ b/azkv/keysource.go
@@ -210,7 +210,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 			"key":     key.Name,
 			"version": key.Version,
 		}).Error("Encryption failed")
-		return fmt.Errorf("Failed to encrypt data: %v", err)
+		return fmt.Errorf("Failed to encrypt data: %w", err)
 	}
 
 	key.EncryptedKey = *res.Result
@@ -244,7 +244,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 			"key":     key.Name,
 			"version": key.Version,
 		}).Error("Decryption failed")
-		return nil, fmt.Errorf("Error decrypting key: %v", err)
+		return nil, fmt.Errorf("Error decrypting key: %w", err)
 	}
 
 	plaintext, err := base64.RawURLEncoding.DecodeString(*res.Result)

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -20,7 +20,7 @@ func File(path, format string) (cleartext []byte, err error) {
 	// Read the file into an []byte
 	encryptedData, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read %q: %v", path, err)
+		return nil, fmt.Errorf("Failed to read %q: %w", path, err)
 	}
 
 	// uses same logic as cli.

--- a/gcpkms/keysource.go
+++ b/gcpkms/keysource.go
@@ -44,7 +44,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	cloudkmsService, err := key.createCloudKMSService()
 	if err != nil {
 		log.WithField("resourceID", key.ResourceID).Info("Encryption failed")
-		return fmt.Errorf("Cannot create GCP KMS service: %v", err)
+		return fmt.Errorf("Cannot create GCP KMS service: %w", err)
 	}
 	req := &cloudkms.EncryptRequest{
 		Plaintext: base64.StdEncoding.EncodeToString(dataKey),
@@ -52,7 +52,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	resp, err := cloudkmsService.Projects.Locations.KeyRings.CryptoKeys.Encrypt(key.ResourceID, req).Do()
 	if err != nil {
 		log.WithField("resourceID", key.ResourceID).Info("Encryption failed")
-		return fmt.Errorf("Failed to call GCP KMS encryption service: %v", err)
+		return fmt.Errorf("Failed to call GCP KMS encryption service: %w", err)
 	}
 	log.WithField("resourceID", key.ResourceID).Info("Encryption succeeded")
 	key.EncryptedKey = resp.Ciphertext
@@ -72,7 +72,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	cloudkmsService, err := key.createCloudKMSService()
 	if err != nil {
 		log.WithField("resourceID", key.ResourceID).Info("Decryption failed")
-		return nil, fmt.Errorf("Cannot create GCP KMS service: %v", err)
+		return nil, fmt.Errorf("Cannot create GCP KMS service: %w", err)
 	}
 
 	req := &cloudkms.DecryptRequest{
@@ -81,7 +81,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	resp, err := cloudkmsService.Projects.Locations.KeyRings.CryptoKeys.Decrypt(key.ResourceID, req).Do()
 	if err != nil {
 		log.WithField("resourceID", key.ResourceID).Info("Decryption failed")
-		return nil, fmt.Errorf("Error decrypting key: %v", err)
+		return nil, fmt.Errorf("Error decrypting key: %w", err)
 	}
 	encryptedKey, err := base64.StdEncoding.DecodeString(resp.Plaintext)
 	if err != nil {

--- a/hcvault/keysource.go
+++ b/hcvault/keysource.go
@@ -123,7 +123,7 @@ func vaultClient(address string) (*api.Client, error) {
 	cfg.Address = address
 	cli, err := api.NewClient(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
+		return nil, fmt.Errorf("Cannot create Vault Client: %w", err)
 	}
 	if cli.Token() != "" {
 		return cli, nil
@@ -239,7 +239,7 @@ func (key *MasterKey) createVaultTransitAndKey() error {
 		return err
 	}
 	if err != nil {
-		return fmt.Errorf("Cannot create Vault Client: %v", err)
+		return fmt.Errorf("Cannot create Vault Client: %w", err)
 	}
 	err = cli.Sys().Mount(key.EnginePath, &api.MountInput{
 		Type:        "transit",

--- a/hcvault/keysource_test.go
+++ b/hcvault/keysource_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 	if err := pool.Retry(func() error {
 		cli, err := api.NewClient(api.DefaultConfig())
 		if err != nil {
-			return fmt.Errorf("Cannot create Vault Client: %v", err)
+			return fmt.Errorf("Cannot create Vault Client: %w", err)
 		}
 		status, err := cli.Sys().InitStatus()
 		if err != nil {

--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -15,12 +15,12 @@ func TestPGP(t *testing.T) {
 			return true
 		}
 		if err := key.Encrypt(x); err != nil {
-			t.Errorf("Failed to encrypt: %#v err: %v", x, err)
+			t.Errorf("Failed to encrypt: %#v err: %w", x, err)
 			return false
 		}
 		k, err := key.Decrypt()
 		if err != nil {
-			t.Errorf("Failed to decrypt: %#v err: %v", x, err)
+			t.Errorf("Failed to decrypt: %#v err: %w", x, err)
 			return false
 		}
 		return bytes.Equal(x, k)

--- a/shamir/shamir.go
+++ b/shamir/shamir.go
@@ -215,7 +215,7 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 		// This polynomial crosses the y axis at `val`.
 		p, err := makePolynomial(val, uint8(threshold-1))
 		if err != nil {
-			return nil, fmt.Errorf("failed to generate polynomial: %v", err)
+			return nil, fmt.Errorf("failed to generate polynomial: %w", err)
 		}
 
 		// Generate a `parts` number of (x,y) pairs

--- a/sops.go
+++ b/sops.go
@@ -596,7 +596,7 @@ func (m *Metadata) UpdateMasterKeysWithKeyServices(dataKey []byte, svcs []keyser
 					Plaintext: part,
 				})
 				if err != nil {
-					keyErrs = append(keyErrs, fmt.Errorf("failed to encrypt new data key with master key %q: %v", key.ToString(), err))
+					keyErrs = append(keyErrs, fmt.Errorf("failed to encrypt new data key with master key %q: %w", key.ToString(), err))
 					continue
 				}
 				key.SetEncryptedDataKey(rsp.Ciphertext)

--- a/version/version.go
+++ b/version/version.go
@@ -74,7 +74,7 @@ func RetrieveLatestVersionFromUpstream() (string, error) {
 			// try to parse the version as semver
 			_, err := semver.Make(comps[1])
 			if err != nil {
-				return "", fmt.Errorf("Retrieved version %q does not match semver format: %v", comps[1], err)
+				return "", fmt.Errorf("Retrieved version %q does not match semver format: %w", comps[1], err)
 			}
 			return comps[1], nil
 		}


### PR DESCRIPTION

* Replaces `%v` formatting of errors using `fmt.Errorf` with `%w`.
* In cases where an `Unwrap` method is not used, `%w` behaves in the _exact_ same way as `%v`.

[Reference:](https://blog.golang.org/go1.13-errors#TOC_3.3.)
> In Go 1.13, the fmt.Errorf function supports a new `%w` verb. When this verb is present, the error returned by `fmt.Errorf` will have an Unwrap method returning the argument of `%w`, which must be an error. In all other ways, `%w` is identical to `%v`.



This would allow returned errors such as this one to check and handle cases when the underlying error is `os.ErrNotExist` using `os.IsNotExist(err)`:
https://github.com/mozilla/sops/blob/8e21de8dbc750f050a54d63209f2f1f93477168c/decrypt/decrypt.go#L21-L24

