### PR TITLE
GCP CloudkmsScope instead of CloudPlatformScope

### DIFF
--- a/gcpkms/keysource.go
+++ b/gcpkms/keysource.go
@@ -131,7 +131,7 @@ func (key MasterKey) createCloudKMSService() (*cloudkms.Service, error) {
 	}
 
 	ctx := context.Background()
-	client, err := google.DefaultClient(ctx, cloudkms.CloudPlatformScope)
+	client, err := google.DefaultClient(ctx, cloudkms.CloudkmsScope)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
sops shouldn't need to reach anything besides KMS and this allows service accounts to be restricted correctly

https://cloud.google.com/kms/docs/accessing-the-api
https://pkg.go.dev/google.golang.org/api/cloudkms/v1