### PR TITLE
Trim space from age keys

### DIFF
--- a/age/keysource.go
+++ b/age/keysource.go
@@ -179,6 +179,7 @@ func MasterKeysFromRecipients(commaSeparatedRecipients string) ([]*MasterKey, er
 
 // MasterKeyFromRecipient takes a Bech32-encoded public key and returns a new MasterKey.
 func MasterKeyFromRecipient(recipient string) (*MasterKey, error) {
+	recipient = strings.TrimSpace(recipient)
 	parsedRecipient, err := parseRecipient(recipient)
 
 	if err != nil {

--- a/age/keysource_test.go
+++ b/age/keysource_test.go
@@ -20,6 +20,16 @@ func TestMasterKeysFromRecipientsEmpty(t *testing.T) {
 	assert.Equal(recipients, make([]*MasterKey, 0))
 }
 
+func TestMasterKeyFromRecipientWithLeadingAndTrailingSpaces(t *testing.T) {
+	assert := assert.New(t)
+
+	key, err := MasterKeyFromRecipient("  age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw  ")
+
+	assert.NoError(err)
+
+	assert.Equal(key.Recipient, "age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw")
+}
+
 func TestAge(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Fix a bug where settings keys in `.sops.yaml` using YAML’s multiline strings results in  `failed to parse input`:

```
$ cat .sops.yaml
creation_rules:
  - path_regex: \.sops\.yaml$
    encrypted_regex: ^(data|stringData)$
    age: >-
      age1XXX,
      age1YYY
$ sops foo.sops.yaml
failed to parse input as Bech32-encoded age public key: malformed recipient " age1YYY": invalid character human-readable part: s[0]=32
```