### PR TITLE
Run CI against master as well

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -2,9 +2,13 @@ name: CLI
 
 on:
   push:
-    branches: [develop]
+    branches:
+      - develop
+      - master
   pull_request:
-    branches: [develop]
+    branches:
+      - develop
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
If you create a PR against master, and then switch it to being against develop, CI still won't run. You have to push up a new commit to re-trigger it.

As well, would be good to run tests again on merges into master.