### PR TITLE
Remove SOPS_GPG_KEYSERVER reference in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -704,12 +704,6 @@ By default, ``sops`` uses the key server ``keys.openpgp.org`` to retrieve the GP
 keys that are not present in the local keyring.
 This is no longer configurable. You can learn more about why from this write-up: `SKS Keyserver Network Under Attack <https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f>`_.
 
-Example: place the following in your ``~/.bashrc``
-
-.. code:: bash
-
-	SOPS_GPG_KEYSERVER = 'gpg.example.com'
-
 
 Key groups
 ~~~~~~~~~~


### PR DESCRIPTION
The `SOPS_GPG_KEYSERVER` environment variable was removed in pull request #732 (_Switch gpg.mozilla.org out for keys.openpgp.org_). However, a reference to the variable was left in the README as "example" in section 2.13 "_Specify a different GPG key server_".

This pull request removes that part.