### PR TITLE
Add arm64 .deb and .rpm builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,6 @@ jobs:
             dist/sops-${{ env.RELEASE_VERSION }}.linux.arm64
             dist/sops-${{ env.RELEASE_VERSION }}.linux
             dist/sops_${{ env.RELEASE_NUMBER }}_amd64.deb
+            dist/sops_${{ env.RELEASE_NUMBER }}_arm64.deb
             dist/sops-${{ env.RELEASE_NUMBER }}-1.x86_64.rpm
+            dist/sops-${{ env.RELEASE_NUMBER }}-1.aarch64.rpm


### PR DESCRIPTION
I needed the ability to install arm64 based sops in a multi-arch Docker image, thus this PR adds the ability for the release process to generate arm64 .deb and .rpm builds.

May be a bit of an overkill with the Makefile variables, but that could make adding more architectures more DRY in the future.

I'm not a Go or Makefile expert by any stretch, but technically this seems to work, and I've verified this by installing arm64 builds in an arm64 Docker image.

This PR **does not** add arm64 support for sops Dockerhub images.

Fixes #595 