### PR TITLE
Update Golang to 1.16

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine3.10 AS builder
+FROM golang:1.16-alpine3.14 AS builder
 
 RUN apk --no-cache add make
 
@@ -8,7 +8,7 @@ WORKDIR /go/src/go.mozilla.org/sops
 RUN CGO_ENABLED=1 make install
 
 
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN apk --no-cache add \
   vim ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mozilla.org/sops/v3
 
-go 1.13
+go 1.16
 
 require (
 	cloud.google.com/go v0.43.0


### PR DESCRIPTION
Golang 1.13 has reached EOL:
https://github.com/golang/go/wiki/Go-Release-Cycle#release-maintenance

Tests should parse, as soon as #882 is fixed.