### PR TITLE
Bump go version for alpine container (#870)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,11 @@ jobs:
           command: |
             docker build -t mozilla/sops .
             docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
+      - run:
+          name: Build containers (alpine)
+          command: |
+            # Just to ensure the container can be built.
+            docker build -f Dockerfile.alpine -t mozilla/sops:alpine .
 
   push:
     machine: true

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine3.10 AS builder
+FROM golang:1.15-alpine3.14 AS builder
 
 RUN apk --no-cache add make
 
@@ -8,7 +8,7 @@ WORKDIR /go/src/go.mozilla.org/sops
 RUN CGO_ENABLED=1 make install
 
 
-FROM alpine:3.10
+FROM alpine:3.14
 
 RUN apk --no-cache add \
   vim ca-certificates


### PR DESCRIPTION
Docker containers are no longer available in dockerhub since v3.7.0.
It's caused for the alpine version container uses go-1.12 and fails to be built.

This request does:
* Updates golang version for the alpine container.
* Build alpine container in Circle-CI for every commits.
    * Just build. No push.
