### PR TITLE
Use the key of release@mozilla.com for the unit test (#882)

### DIFF
--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -44,7 +44,10 @@ func TestPGPKeySourceFromString(t *testing.T) {
 }
 
 func TestRetrievePGPKey(t *testing.T) {
-	fingerprint := "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+	// Requires a key available in https://keys.openpgp.org/ *with identity information* (that is, an email address).
+	// See https://keys.openpgp.org/about/faq#verify-multiple for details about identity information.
+	// We use the key of release@mozilla.com for here.
+	fingerprint := "14F26682D0916CDD81E37B6D61B7B526D98F0353"
 	_, err := getKeyFromKeyServer(fingerprint)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
* `golang.org/x/crypto/openpgp` requires keys contain identity information.
* A email address can have only a single key with identity information on keys.openpgp.org.

`secops@mozilla.com`, used in keys for unit tests is currently associated to 388B914AFF8BC589962CFA2D996E14AC4DB5EC62: https://keys.openpgp.org/search?q=secops%40mozilla.com
I'm not sure it's permanent one.

The key for `release@mozilla.com` is used for release of FireFox, and I believe we can rely on that's permanent.
https://keys.openpgp.org/search?q=release%40mozilla.com
