### PR TITLE
Allow empty maps for yaml (#907)

### DIFF
--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -361,11 +361,7 @@ func (store *Store) EmitPlainFile(branches sops.TreeBranches) ([]byte, error) {
 		mapping.Kind = yaml.MappingNode
 		// Marshal branch to global mapping node
 		store.appendTreeBranch(branch, &mapping)
-		if len(mapping.Content) == 0 {
-			doc.HeadComment = mapping.HeadComment
-		} else {
-			doc.Content = append(doc.Content, &mapping)
-		}
+		doc.Content = append(doc.Content, &mapping)
 		// Encode YAML
 		err := e.Encode(&doc)
 		if err != nil {

--- a/stores/yaml/store_test.go
+++ b/stores/yaml/store_test.go
@@ -198,6 +198,15 @@ func TestEmpty2(t *testing.T) {
 }
 */
 
+func TestEmpty3(t *testing.T) {
+	branches, err := (&Store{}).LoadPlainFile([]byte("{}\n"))
+	assert.Nil(t, err)
+	assert.Equal(t, len(branches), 1)
+	bytes, err := (&Store{}).EmitPlainFile(branches)
+	assert.Nil(t, err)
+	assert.Equal(t, "{}\n", string(bytes))
+}
+
 func TestComment6(t *testing.T) {
 	branches, err := (&Store{}).LoadPlainFile(COMMENT_6)
 	assert.Nil(t, err)


### PR DESCRIPTION
Fixes #907

This allows following usage in sops-3.7.x, just like in sops-3.6.x and earlier.
```
echo '{}' | sops --input-type yaml --output-type yaml -e /dev/stdin | sops --input-type yaml --output-type yaml -d /dev/stdin
```
