### PR TITLE
Tests should not fail fast

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -3,10 +3,18 @@
 set -e
 echo "" > coverage.txt
 
+failed=0
+
 for d in $(go list ./... | grep -v vendor); do
-    go test -race -coverprofile=profile.out -covermode=atomic $d
+    go test -race -coverprofile=profile.out -covermode=atomic $d && true
+    rc=$?
+    if [ $rc != 0 ]; then
+      failed=$rc
+    fi
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out
     fi
 done
+
+exit ${failed}


### PR DESCRIPTION
`test.sh` stops running as soon as it finds a test failure in a module (so-called fail fast).

Generally speaking, it's not a good idea:
* Developers have to fix tests one by one. They fix a test, run tests again, find a next test failure, fix that, run tests again, find a next test failure...
* Developers cannot see all test results if they don't have complete testing environment. (e.g. consider one without Docker in his/her environment)
* CI doesn't show whether a pull request works correct if some existing test breaks for itself (e.g. #882 )

