### PR TITLE
Redirect signals to a child process

### DIFF
--- a/cmd/sops/subcommand/exec/exec_unix.go
+++ b/cmd/sops/subcommand/exec/exec_unix.go
@@ -12,7 +12,9 @@ import (
 )
 
 func BuildCommand(command string) *exec.Cmd {
-	return exec.Command("/bin/sh", "-c", command)
+	cmd := exec.Command("/bin/sh", "-c", command)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+	return cmd
 }
 
 func WritePipe(pipe string, contents []byte) {


### PR DESCRIPTION
Hi!

Currently, SOPS doesn't redirect any signals to the child process when running in `exec-file` or `exec-env` modes so the child process can't react to a signal (e.g. `SIGHUP` for reloading or `SIGTERM`/`SIGINT` to shutdown graceful). Instead, SOPS shuts down without giving any chance to the child process.

This PR causes SOPS to wait for the child process to finish first and redirect all the signals it receives to the child process. Also, child processes are created with different process group ID which means that only SOPS receives signals, and not both.


Fixes https://github.com/mozilla/sops/issues/840
Related https://github.com/mozilla/sops/pull/880
