### PR TITLE
Set GPG encrypt. conform. to RFC4880 Fixes #896

### DIFF
--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -63,6 +63,7 @@ func (key *MasterKey) encryptWithGPGBinary(dataKey []byte) error {
 		fingerprint = fingerprint[offset:]
 	}
 	args := []string{
+		"--rfc4880",
 		"--no-default-recipient",
 		"--yes",
 		"--encrypt",


### PR DESCRIPTION
Resolves an issue where a file encrypted with GnuPG 2.3 which defaults to enabling RFC4880bis) can't be decrypted in earlier versions (eg. GnuPG 2.2 as used in Debian Buster)

I have tested encryption on GnuPG 2.3.1 on Windows, and subsequent decryption on GnuPG 2.2.12 on Debian Buster.

(this is recreation of #910 rebased onto the develop branch)