### PR TITLE
Correct the folder of age keys on macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ the ``--age`` option or the **SOPS_AGE_RECIPIENTS** environment variable:
 When decrypting a file with the corresponding identity, sops will look for a
 text file name ``keys.txt`` located in a ``sops`` subdirectory of your user
 configuration directory. On Linux, this would be ``$XDG_CONFIG_HOME/sops/keys.txt``.
-On macOS, this would be ``$HOME/Library/Application Support/sops/keys.txt``. On
+On macOS, this would be ``$HOME/Library/Application Support/sops/age/keys.txt``. On
 Windows, this would be ``%AppData%\sops\keys.txt``. You can specify the location
 of this file manually by setting the environment variable **SOPS_AGE_KEY_FILE**.
 


### PR DESCRIPTION
Relates to https://github.com/mozilla/sops/issues/914