### PR TITLE
Add `--shell path` option to exec-{env,file} subcommands.

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -132,6 +132,10 @@ func main() {
 					Name:  "user",
 					Usage: "the user to run the command as",
 				},
+				cli.StringFlag{
+					Name:  "shell",
+					Usage: "invoke shell to exec command",
+				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if len(c.Args()) != 2 {
@@ -163,6 +167,7 @@ func main() {
 					Plaintext:  output,
 					Background: c.Bool("background"),
 					User:       c.String("user"),
+					Shell:      c.String("shell"),
 				}); err != nil {
 					return toExitError(err)
 				}
@@ -186,6 +191,10 @@ func main() {
 				cli.StringFlag{
 					Name:  "user",
 					Usage: "the user to run the command as",
+				},
+				cli.StringFlag{
+					Name:  "shell",
+					Usage: "invoke shell to exec command",
 				},
 				cli.StringFlag{
 					Name:  "input-type",
@@ -237,6 +246,7 @@ func main() {
 					Background: c.Bool("background"),
 					Fifo:       !c.Bool("no-fifo"),
 					User:       c.String("user"),
+					Shell:       c.String("shell"),
 					Filename:   filename,
 				}); err != nil {
 					return toExitError(err)

--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -24,6 +24,7 @@ type ExecOpts struct {
 	Background bool
 	Fifo       bool
 	User       string
+	Shell      string
 	Filename   string
 }
 
@@ -65,7 +66,7 @@ func ExecWithFile(opts ExecOpts) error {
 	}
 
 	placeholdered := strings.Replace(opts.Command, "{}", filename, -1)
-	cmd := BuildCommand(placeholdered)
+	cmd := BuildCommand(placeholdered, opts.Shell)
 	cmd.Env = os.Environ()
 
 	if opts.Background {
@@ -96,7 +97,7 @@ func ExecWithEnv(opts ExecOpts) error {
 		env = append(env, string(line))
 	}
 
-	cmd := BuildCommand(opts.Command)
+	cmd := BuildCommand(opts.Command, opts.Shell)
 	cmd.Env = env
 
 	if opts.Background {

--- a/cmd/sops/subcommand/exec/exec_unix.go
+++ b/cmd/sops/subcommand/exec/exec_unix.go
@@ -11,8 +11,12 @@ import (
 	"syscall"
 )
 
-func BuildCommand(command string) *exec.Cmd {
-	return exec.Command("/bin/sh", "-c", command)
+func BuildCommand(command string, shell string) *exec.Cmd {
+	if shell == "" {
+		return exec.Command("/bin/sh", "-c", command)
+	}
+	return exec.Command(shell, "-c", command)
+
 }
 
 func WritePipe(pipe string, contents []byte) {

--- a/cmd/sops/subcommand/exec/exec_windows.go
+++ b/cmd/sops/subcommand/exec/exec_windows.go
@@ -4,8 +4,11 @@ import (
 	"os/exec"
 )
 
-func BuildCommand(command string) *exec.Cmd {
-	return exec.Command("cmd.exe", "/C", command)
+func BuildCommand(command string, shell string) *exec.Cmd {
+	if shell == "" {
+		return exec.Command("cmd.exe", "/C", command)
+	}
+	return exec.Command(shell, "/C", command)
 }
 
 func WritePipe(pipe string, contents []byte) {


### PR DESCRIPTION
As a contrived example, if file _o1.json_ contains:

> {
>   "foobar": "eval echo '$\\u2573'"
> }

then the command `sops exec-env --shell /bin/bash o1.json '$foobar'` produces: **╳** instead of **$\u2573** without the `--shell path` option.

One unfortunate discrepancy between dash and bash can be illustrated with the example file o2.json: