### PR TITLE
Build alpine container in CI (#870)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,11 @@ jobs:
           command: |
             docker build -t mozilla/sops .
             docker tag mozilla/sops "mozilla/sops:$CIRCLE_SHA1"
+      - run:
+          name: Build containers (alpine)
+          command: |
+            # Just to ensure the container can be built.
+            docker build -f Dockerfile.alpine -t mozilla/sops:alpine .
 
   push:
     machine: true


### PR DESCRIPTION
Docker containers are no longer available in dockerhub since v3.7.0.
It's caused for the alpine version container uses go-1.12 and fails to be built.
It's fixed in #1012.

I want to let CI test building alpine containers so that the problem won't be reproduced.
