### PR TITLE
Remove duplicated stage from Dockerfile.alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,3 @@
-FROM golang:1.12-alpine3.10 AS builder
 FROM golang:1.17-alpine3.15 AS builder
 
 RUN apk --no-cache add make


### PR DESCRIPTION
Building image fails with the following error.

```
$ docker build -t sops -f Dockerfile.alpine .
Sending build context to Docker daemon  884.2kB
Step 1/11 : FROM golang:1.12-alpine3.10 AS builder
 ---> 6d6865cf688e
builder stage name already used
```