### PR TITLE
Update examples to include age-encryption

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -2,3 +2,6 @@ creation_rules:
     - pgp: >-
         FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4,
         D7229043384BCC60326C6FB9D8720D957C3D3074
+      age: >-
+        age1tmaae3ld5vpevmsh5yacsauzx8jetg300mpvc4ugp5zr5l6ssq9sla97ep,
+        age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw

--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,23 @@ the ``--age`` option or the **SOPS_AGE_RECIPIENTS** environment variable:
 
 .. code:: bash
 
-   $ sops --encrypt --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw test.yaml > test.enc.yaml
+   # encrypt
+   $ sops --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw  -e test.yaml > test.enc.yaml
+
+   # decrypt
+   $ sops --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw  -d test.env.yaml > test.yaml
+
+Or, if you whish to encrypt the file in-place
+
+.. code:: bash
+
+   # encrypt
+   $ sops --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw  -e -i test.yaml
+
+   # decrypt
+   $ sops --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw  -d -i test.yaml
+
+
 
 When decrypting a file with the corresponding identity, sops will look for a
 text file name ``keys.txt`` located in a ``sops`` subdirectory of your user
@@ -198,6 +214,19 @@ per line. Lines beginning with ``#`` are considered comments and ignored. Each
 identity will be tried in sequence until one is able to decrypt the data.
 
 Encrypting with SSH keys via age is not yet supported by sops.
+
+Test with the dev AGE key
+**********************
+
+If you want to test **sops** without having to do a bunch of setup, you can use
+the example files and AGE key provided with the repository::
+
+	$ git clone https://github.com/mozilla/sops.git
+	$ cd sops
+	$ export SOPS_AGE_KEY_FILE="$(pwd)/age/keys.txt"
+	$ sops example.yaml
+
+This last step will decrypt ``example.yaml`` using the test private key.
 
 
 Encrypting using GCP KMS

--- a/example.ini
+++ b/example.ini
@@ -1,31 +1,29 @@
-; ENC[AES256_GCM,data:EexYkXJHDv1E9WwU8wUrBakxAZcnlIkAJQgRFts3alF+5w==,iv:/wd7bCxSkJ85eG69NMq2RH70Dlw5q/diL42GcdTbRYs=,tag:8W4B3JjLYAtJgG3Zi6Hu+A==,type:comment]
+; ENC[AES256_GCM,data:5fcY598HE7ZTqPIkwyxD/BNgulcjMB2YnAhdXdzpFqZFpg==,iv:x8VI3crQB8Wtf4tbMTo/JOQoA5OgUvSGfpbZD2BTxyk=,tag:LeuBPf0gNMi6c9AQ5fZwww==,type:comment]
 [name]
-firstName = ENC[AES256_GCM,data:7cWtsg==,iv:rh/1l0yiOE3JmmSJB9CXp4Ctb5en0FcNUZZkLyWsX3c=,tag:d7We6RtSs3AYhA6jan/CoA==,type:str]
-lastName  = ENC[AES256_GCM,data:Iq50v00=,iv:o+bfCsNBsv/+XdXS4M7TCOTPzG38ft14/Q9/vZvnNvM=,tag:cRivFOZyIpMDXdKA9R+6mA==,type:str]
-age       = ENC[AES256_GCM,data:aSt9Fg==,iv:z1NjXdRRFs8+dAFkrngS7PyhUSCOTzAmxtzCcfafkAM=,tag:6kpo65TxMu1oKF9d7L1wJg==,type:str]
+firstName = ENC[AES256_GCM,data:dB9CbA==,iv:RCy4ITsGfCFOmneQPSiixq0GI5aTjLw9/TRAKkp7EI8=,tag:cphRC2nI5aWey1UIig39wQ==,type:str]
+lastName  = ENC[AES256_GCM,data:3uhujg4=,iv:0XqzkXcB1FjDyt+B9WbPVeezD0epUPp/OB+X+pKG6pI=,tag:oUvico+KCZhTT14pGRVXaQ==,type:str]
+age       = ENC[AES256_GCM,data:nTp0lg==,iv:6f1oNdMBTJdpI1PSV/PW8H3ZiCygY9tgmlcCN4sKP1Q=,tag:18Rwfv/hm24FyZGWD3VHIQ==,type:str]
 
 [address]
-city          = ENC[AES256_GCM,data:3hQ6RXAc8ik=,iv:ajAjhQIJiNWy9PGj8ZCI5k+3uw7igweqZ+eiZ9tuvG0=,tag:bGX7PK+/hTQE/1uYmXexyA==,type:str]
-postalCode    = ENC[AES256_GCM,data:1Ha0avZTe6IflQ==,iv:l8rbQbhSwxr3AJzqe/H8ALrHcXsntcBfkyUGt9/6k/U=,tag:f6s6ObY5QaqmG4CUpV+UKg==,type:str]
-state         = ENC[AES256_GCM,data:ba0=,iv:P/VsGYbhT8ihRvluWc8HcUDPPigh/IcHXBnj0Xb86AE=,tag:JN7Y77eOaF1+tJjN2cxtnQ==,type:str]
-streetAddress = ENC[AES256_GCM,data:LYYluDyJzryoYT2Nkg==,iv:KTmXPVV5tSY8/piTb/uPcfJL2mUqkS1aUI9pukQm1Dc=,tag:AzdSsRjEWx8kzclSZIdIcA==,type:str]
+city          = ENC[AES256_GCM,data:3yiuuI/ORzQ=,iv:c+QkU92/tqpRYTpEln+YamyAez9fHUImc9LxDz1IFC0=,tag:4zCTPif/PJT3de5bOHe59w==,type:str]
+postalCode    = ENC[AES256_GCM,data:O9jUhQCCHf6EIw==,iv:PQCpmMYi7XToq4ojmvYvwHbE4dRgHrrPvlkxPK04n38=,tag:sTsMnDXKDpng0uAy1EbmzA==,type:str]
+state         = ENC[AES256_GCM,data:/SY=,iv:DZoe2bnlHgN1MlT1iO4k6c8lFQN+9L/tY0UsmzvDsvg=,tag:yya4buQadn9eRoqnwbNZIw==,type:str]
+streetAddress = ENC[AES256_GCM,data:ncDeIoroAFgtOLg/SA==,iv:NQi88EnsB5KVPo2SQwbkVtUwbQwyWGKx33qeFSG1i6c=,tag:sV900aVOJZlPJX8JrslQYw==,type:str]
 
 [phoneNumbers]
-home   = ENC[AES256_GCM,data:wv3pG8J7wmiotVY6,iv:YdX9RKlN9t0PohEu+Dxws0POUf8hjDMi4PJre+4/lsg=,tag:2XadWng1DxnfMituylFC5g==,type:str]
-office = ENC[AES256_GCM,data:Hu3X626TUgV3Ix7i,iv:P1SBjvZPogJih4KLFLcbxeWeZT2aTNXPBtwlC9yZZ70=,tag:4SOkQZw4ynKfrFwrmre6Lw==,type:str]
+home   = ENC[AES256_GCM,data:XUaAcpmLhfpbhCbj,iv:Sp7bZBpjSiV5Eq2F3fP7saylpM+BRFEFe+fali6EcR8=,tag:zWPWedB99c6EYzMiP71I0A==,type:str]
+office = ENC[AES256_GCM,data:8CWhq8UzBsSZ60CC,iv:j98DB2S9Ro8mMhoEoABiiU1aBiw8Qcz4r7NssCexfHk=,tag:cQpunXOnaFOXIdQyxl19Ug==,type:str]
 
 [not private]
 notsecret_unencrypted = hi there!
 
 [sops]
-pgp__list_0__map_fp         = FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
-pgp__list_1__map_created_at = 2019-12-10T22:45:52Z
-pgp__list_1__map_fp         = D7229043384BCC60326C6FB9D8720D957C3D3074
-lastmodified                = 2019-12-10T22:45:52Z
-pgp__list_0__map_created_at = 2019-12-10T22:45:52Z
-pgp__list_0__map_enc        = -----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAGb6tDB1gDtwLcVuENgd/AU1ZjxDbUY46OJzi1fkQ4jyo\nvxfCviqfslYyncVrKab0S9U+alIu8Po8BrHCTwmDkcnPG7HWMcqRo+Nq3JShir3y\ntVMbHuRGykPmGjs7GOUn1WibOisiJjHzLdFOsyNexveBV9AVln7kZazCRlXwbLqc\nyJ9IQsWi1ET6DjtViejiBKblDzZ87WgvL2Z0E8QfYXmrB3GpFa+K4Aqgb3pHkQQo\nGQArNAe8BmrhEXotj0IS/K3v2wjX5Sqli+0dh4qhaXiIeYb16nfc4M1TUo4Vvj7Q\nyWdjufTi+2RIxxUEkIdRg6lDVabm98hLn6/jsQ5c5tLgAeT99N9te4j1eeO62xwy\nz4S+4Xok4Cng9OFHFODz4hh6ah3gYuXRf4qFh++GUaxGwG/iGNSiY7A9eWg1gM+N\nPB6MtiOnhuB15N5mbD2V1xrzlF0fu0K98Vviv75h4eGzYQA=\n=RaGg\n-----END PGP MESSAGE-----
-mac                         = ENC[AES256_GCM,data:5NouZe0uY8581eqXLe31TWYqThPlfePdpIyYDBgj3FwGvPfhiWB+dn/diSt4NpZ9zUNI4VhF2cmNesk8NgZdUK9/N9WbGgmJjjdBXvo0xhvr8RR22AiVCB9ipDlSFqnOMyJzo+CAvpSDbwF1bMU0qxwKW+zpDZV2uLX+px7b2qM=,iv:em3/lIV7eYA46u2kM0bR1/3O6Ga2vRfS5/r2qh0jges=,tag:ow9277u7mFNcs4IdsU4YUQ==,type:str]
-pgp__list_1__map_enc        = -----BEGIN PGP MESSAGE-----\n\nwYwDXFUltYFwV4MBBAAQYkLcQ1MORGYYprtFwUZPO2J3CBOU4u76qJQod5JXZuAa\n3aCynkyrOHIpgh2cKoyUle4u/FK68mFl9+TxixlFDRxt1CsvMR8dHP0EFJOMSq5U\nNwpcnEh20++3DNiq7bCtS2W68FRh8bVxmhEEXPxW4HLJV4WZSE4pu9B7w9kd5NLg\nAeQyj0ugpILq3IonJdLsgLkg4RGV4GDgFOEqxOCT4uKeSX/gdOXvr5WJzlWJRLjT\nA51CtgnUVXlNO5zfCiFRMXOFyE1FCeBm5Ivkgh4KxkQvwI6jSZpU1rjiz4QYTOGO\n4gA=\n=XdTd\n-----END PGP MESSAGE-----
-unencrypted_suffix          = _unencrypted
-version                     = 3.5.0
+version                    = 3.7.1
+age__list_0__map_recipient = age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw
+age__list_1__map_enc       = -----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoMWhoWi9XUlo1Z01DUnZw\nRHZXWkdvbzJHMlZQSm0vdkg1TFlXenFOWEFZCjNFUlZmc0VUaU9obG5scEtiMU0z\nU1hMWnU0c2hjQlZmQXdPU2tHM0MvM00KLS0tIGhKNXZtZWI3Tjl4MkVjQlNzcjRk\neDFQVjhZT0ZWYXkzUWhzM3BuT2xFVzAKau843+WEnq+3opLKOSF3/PYEEpAl9ach\nqkynqqZq+q7HwSpb9FupJcIYIoc+bCpLb70Qrb/eKytBebVcTGdCzw==\n-----END AGE ENCRYPTED FILE-----\n
+unencrypted_suffix         = _unencrypted
+lastmodified               = 2022-03-15T22:12:10Z
+mac                        = ENC[AES256_GCM,data:KQRpDAttr7lXUtb05p0A1fefZzrAidLFxf3COvZkV25nBG/jGuL8WscfN0RK1ieatk+RR9GsBdZ3eXbmkn53s414hc/5hpQKrcoZEM+UfBeEBzLmPDU6Z3AUMOhVEacG4tsZZuWVmbBQwRxMA7L6Lwzl9za+dtq+ZxveNTf3gYY=,iv:SBPz15arkm4Yy4gssywOUlgQOtX7lgUvF8Vb3jR2idc=,tag:bjyVll5uCTGG3E0gieUgig==,type:str]
+age__list_0__map_enc       = -----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1R1E0QVA1R3NXaWU4RVdJ\nQy9tTXoyREl6QWxNK1JoMUR1cXBWZmplR1NrCllJOG1YMEoyWFBUR3pKNjRtZ3pa\nU1lHa09KNDFMYVRmL1FvcGtZRmtrZG8KLS0tIGpqS25HejR6NzNkRmZTdlRFdGl3\nSnV5bnBYRTcycDZPSGU3aFdSb2I3WXMKtNTaLtrMzyKsbJHGjhVg/XwssbnwUe75\namcsPsbE2upBy3SAdScsJlNQ5zAY4rF+aq2FJeC3ab8RteAbvetq1w==\n-----END AGE ENCRYPTED FILE-----\n
+age__list_1__map_recipient = age1tmaae3ld5vpevmsh5yacsauzx8jetg300mpvc4ugp5zr5l6ssq9sla97ep
 

--- a/example.json
+++ b/example.json
@@ -1,21 +1,21 @@
 {
-	"firstName": "ENC[AES256_GCM,data:f8++3g==,iv:rYuVzzb+C40QlYgO4Dl2V7atZUx0ITBcyb5fUsftKMo=,tag:krquPqa1HQltZqidzNamrA==,type:str]",
-	"lastName": "ENC[AES256_GCM,data:94a2Q8c=,iv:c3NC7L80UTtbz7gdvPV5oSUwg30lC3Kg82uvRVs5CZw=,tag:kUXRNerUWmSe44mwD4w5uA==,type:str]",
-	"age": "ENC[AES256_GCM,data:gjwWkw==,iv:XEWFpsyvEsPwr3qqsOJlfZ+vSZdiA+D6DAc6aoq/BS0=,tag:pcnUyMtYFa9v5DB6sNV15w==,type:float]",
+	"firstName": "ENC[AES256_GCM,data:BI/mJA==,iv:ZojqEcQXP8/LyABBbQvcdzY/4PGmR8Q1E8A/b/RtEQk=,tag:YlyRWpnno1rh3f8/+aZa+Q==,type:str]",
+	"lastName": "ENC[AES256_GCM,data:yCl85sw=,iv:tOpTIExH/3ECW1a9iyu6M/tQOK+nQegnSQrvC/kDyJU=,tag:Gd9PMhhJeF/fcnC0WR2g1A==,type:str]",
+	"age": "ENC[AES256_GCM,data:51fTIg==,iv:EdUHckdg0hZkee0gQ5A0uNxvM4K0HYuh4Tl/DQo/10k=,tag:cim/THOLAGIeXmBAbvTCnA==,type:float]",
 	"address": {
-		"city": "ENC[AES256_GCM,data:vSeyQwN1Z9k=,iv:DBmuX4w6w14Z/1b820OE3SM3MPx3oLGAeSoR4CWxdhg=,tag:ClpJZLb4ObIOdDD441clrw==,type:str]",
-		"postalCode": "ENC[AES256_GCM,data:SZadC4tZh106eg==,iv:z/yWCZTd19j+3cFY5mwVkxY8a7i6veTBnwh4fsw5Kbw=,tag:iel9Pqh0jS0KhjxklXeqIg==,type:str]",
-		"state": "ENC[AES256_GCM,data:b0Y=,iv:7Ar/Tb7XCDo5ABZNdSNBqGquaGEQF7dNxd1VvW7Nwak=,tag:uEjmOKwPlkYSq4IV1tQjwQ==,type:str]",
-		"streetAddress": "ENC[AES256_GCM,data:dVFPTRPKOFSJ1plV9w==,iv:08Ks4C1FzFozezKBBYSPEAIkC5DkthDFmMW0R3zVbkI=,tag:waInfXMCAcx5C7avXHahOw==,type:str]"
+		"city": "ENC[AES256_GCM,data:QkcU0rd9qmU=,iv:Wsyapcu/xqq5CY+NzU2l/0cT3AdWh7i/RokgzfwB29k=,tag:C/f3AOltNNX0YPCeCEVabw==,type:str]",
+		"postalCode": "ENC[AES256_GCM,data:OMB0H17W2b92Fg==,iv:ph4sySHoBQKBEn03CEvP1S2zEfGhWCQ2SvJEGPVHnG4=,tag:3X4w9o9OfKzZctxEs7npgQ==,type:str]",
+		"state": "ENC[AES256_GCM,data:Acc=,iv:9CbqQRysoxNFst8bdHUmV/Uai1CMeQel+1Rl44rBxnA=,tag:0eCXwtsOU31ILrho+viLEA==,type:str]",
+		"streetAddress": "ENC[AES256_GCM,data:6bL/w0QmwGY5FCLmDQ==,iv:6/lWFHOj54+gWXFcc7Vy6RKuzq8nZlP9oCOo//1Jtok=,tag:P2KJcKlEeqe0Jhckd6Wnvw==,type:str]"
 	},
 	"phoneNumbers": [
 		{
-			"number": "ENC[AES256_GCM,data:lkUEC7s3qU9AY6W+,iv:KjF9i0K9u7THbb3Bn1adQrIKpv1ZqA3PiJkctgFm3Bw=,tag:LBSqqr+gn15x0Pz5JKMJJQ==,type:str]",
-			"type": "ENC[AES256_GCM,data:aXBHGg==,iv:ulcjNwVfGFvUtVN8q0h1LMYM5zRDmOsqtoFC1JOHREY=,tag:7vdMoCOD+7IeUHWQqQJ8XA==,type:str]"
+			"number": "ENC[AES256_GCM,data:Es1mxlh42TsCP6dI,iv:GR5neCruf4VnXh7z6xxpCEEtzzaCMUBUiL+/AW4gKYk=,tag:z3ScUji+1of3fUH+cK6eBg==,type:str]",
+			"type": "ENC[AES256_GCM,data:tU126A==,iv:0edAcKYEFms9MW0TuLq7OVGdHWbuehdnSrD4/IqpxRE=,tag:CjQqs9YjGUvDgHPsN18U1w==,type:str]"
 		},
 		{
-			"number": "ENC[AES256_GCM,data:z9Ujp3n2yXBqPNM1,iv:1nbZrIKozuS2p2AgD5/gHgjMN/VSd8SFeCbWdjy9Cf0=,tag:tfwaYihQDMAsmy/yt6ScLg==,type:str]",
-			"type": "ENC[AES256_GCM,data:ddkB7Iu6,iv:4t31C5r1zhCpLQ64idoJ8OBC7ocME15zCUXCmgf2ItY=,tag:RmBsmbhQW10oOTDuzfxEaA==,type:str]"
+			"number": "ENC[AES256_GCM,data:uFvyF6ovpVMiEh2t,iv:sbqsePKuvyvRNzyMrbSHe8NeH13SvPqZNYeOLiCm3Tk=,tag:yL6PD8lHXFp30Er6fGtvyw==,type:str]",
+			"type": "ENC[AES256_GCM,data:32/bPy4i,iv:V7d2ruA0aWUDTbkTLxuoPYaGjNAiCQ7XrTkLzMoQhGk=,tag:vnDWHS/RXl9HrIkge2Tbqw==,type:str]"
 		}
 	],
 	"anEmptyValue": "",
@@ -23,21 +23,21 @@
 		"kms": null,
 		"gcp_kms": null,
 		"azure_kv": null,
-		"lastmodified": "2019-12-10T22:45:55Z",
-		"mac": "ENC[AES256_GCM,data:VoXDgYpIYCvFSLyKGx4c8yk56Mk5GkeIwM8IyUi4RgkKBY/xEIzNUOuMqBzWEOvTTsivF/JtUOrBIsDRxGY0u0qNJK1R5WFuSYr3TA5sdu3ytMcu+mKY4THSJN8uuri/tXVcoF+ywLOS6NRFbHDJPtJGcy1XQwJJAgvdw+sIvQA=,iv:dvk3FYXHr2N6gYIw2OqbYiHn6FfXzuyHqZvJIo6IVGM=,tag:rjnNkJSGpXJ762EyjDltXg==,type:str]",
-		"pgp": [
+		"hc_vault": null,
+		"age": [
 			{
-				"created_at": "2019-12-10T22:45:55Z",
-				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAMSeWf3F8kIm8EFiVgGVQgWGIHUVoolToi8d8lAC8/UdK\ncx9dIqlR43IFvvmCKyNZ6Q+/a1ERc07xLpVp3wmN80sE4NZCGZioThZjp2qNS42e\n/HtLfDu+Rie1eKcXEik40rMDn7d8gaFVOpD3FbzoZUFVm8hN5ChzqQqL1nLy9ZgY\nbthH3Rzt58Z1/sxARLNF2/yUqAEX/YEoL0MxM68Z55kwiMqSZ1rdmLKKfXdJbdoL\nSRrFyi+XaAwr1bTD+BnqHqgmYEEWEfHPDW7e1St/4IS4PU98kKuVLjhBKbfTRUpF\nkzxt+XQV6uDfPzdeOzf+JrFMRaoxTRMpcUi4Jn0vstLgAeSAjSzqkUr6DEVsuS8V\nAqRD4Z9I4HHgy+GYruDQ4kDtTvPgbeUWFma5yz25JOoORZIHaGiEB3T8ZhrFD8VI\ndFLxtxLtCeCg5BhRcrxFgWPQCMK/uCt/GFniNf4Y2OGOHQA=\n=r/lV\n-----END PGP MESSAGE-----",
-				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+				"recipient": "age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpUkQ0SE5Qa0hScS9FdVNy\nNC9MS1lLSG9DTmsyRnVrQUdYWmIvRURvY0RvCm1uQkNONWV1aUU4UUhSUDQxUW44\nMGoyNERHZnRIYk5VRnhjSHZaVmt4Tm8KLS0tIHUxYVFHWE5RbmIyM2xLdm45cGZs\nd1loQ09tQTNkZWNsdzhyWC96TVh4ZmMKW2goiZpvSm5BmxvTKUUojof2mOtnMv3K\nAka7Uf4GLfssMHDEKh9ZbtU79+IuR6rfCTn3ZbqyxyEIpP9eITcmWw==\n-----END AGE ENCRYPTED FILE-----\n"
 			},
 			{
-				"created_at": "2019-12-10T22:45:55Z",
-				"enc": "-----BEGIN PGP MESSAGE-----\n\nwYwDXFUltYFwV4MBBABs0ZEghsU+mdsRFROvlT8ACqk4Ru0Bssw3N+lkSrpR+QyY\nuRgAFNmZgPKz4DhZLHbhOD0zAAHuMCGriXVqtxMYMveX1nbXom+ayBmU0jja+6X2\njwk0MghHS1bgIsGrrhPoD7c3iirdaXSgHKAxwl4bpw5OxW6t91moOtJ4DAyGXdLg\nAeTkQxUyLFEeUbx4xX7kNCm+4Yho4CngDuH4oOD44gSWJsjgU+XiRBuJa50tiloC\nA10yQkWZtuyPOWppO5qOdXqV3XDIeOBl5JSNFuv5B80w8UIYhPPXWpriV1nBveE/\nwAA=\n=Vg44\n-----END PGP MESSAGE-----",
-				"fp": "D7229043384BCC60326C6FB9D8720D957C3D3074"
+				"recipient": "age1tmaae3ld5vpevmsh5yacsauzx8jetg300mpvc4ugp5zr5l6ssq9sla97ep",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjK2ZDRjV3cHVqYmtzYjgy\nNFNsZkFiTUFkdGtUM2FPdytLQ1EzeUFMMnlzCldoK2c5TERmZDJVb2RSZjlSSGRR\nMXlEcURDbnhLelJiV0ZLclBycXcyY0UKLS0tIDZ4MG5vdWpNcWU0emVzU3IyYk1v\nMWc0UVNPOEhtQkNxYVNDUXUzaVJvVjAKXCMvVaqrthddEL5/511DZBdDYaayE+W6\n2WGlW+xiDeRewUTtjpzH4GTra8sUaqQe5vJNNSi5OxA7tBfGbGmhyQ==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
+		"lastmodified": "2022-03-15T22:12:12Z",
+		"mac": "ENC[AES256_GCM,data:LDAtlWNbwOykpJ5EPWRvBjHJN5x426SoxGoLlSkORSFhcNnYPAAB9ubwGr7tGps6Rs02+hod/Nej2nHPVupZV+Wf7pZwvppRIpDiHVT+ZnhMYg11iBVSxHv4bw7mmpFSfJTeoTKR2B1p5gzMAV6oLHUC107SyDZ3NHManNJXKEM=,iv:LBFbfgxRa4O3iuJf9W9G1xdROkujH1Iu7/JExXNmRRQ=,tag:5vhy4U6iRjnWdqSpMgOYeA==,type:str]",
+		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.5.0"
+		"version": "3.7.1"
 	}
 }

--- a/example.txt
+++ b/example.txt
@@ -1,24 +1,24 @@
 {
-	"data": "ENC[AES256_GCM,data:p6kOd9e7KOYw47VlNlKa52wPFfbY3xaJYQrO5QDT1LyNvUIVBSRTrJxvn5MCC7vdnTOkcBzWmlr6Z/Q23/sx22++3Y7nXTSgFPQxPVIA8X33OoIsCamNHS8+8JWOReALCf2Cd3rzedu0GWR+/f2YBSHNA3C4nffEDbWbXRyAvcvCv3G4umH+Jh9auWUlfbk3Bx/8LvX6DodcxhQ=,iv:ESrDyOG6qetEWGBNHWRpT6ra1NhpaFH3SnjBSdMj2r0=,tag:aP5vOboB64cJDUls9WKsTA==,type:str]",
+	"data": "ENC[AES256_GCM,data:g9pVRcxC4BPHzQdfpRUm8Bs/6l1FKkfHNpOUBkrk+qBV2SGkP0D6Yb6WZUnqQK1e5it7LCCmaPFj3LxB+19O6rl1O4cRSOv2OLBZFFyEv4jcdU6aIlzWo4PaTWzDNLhw/B2TAyYdRvsrf6IY2HGe+VJffe+IhUaltUEQDgSC0z52nDlnmc+kSM26k0tBqho3yeHypHdRz5hpu/w=,iv:r98jRKKTa11ebDqqu8uhxpTFlLQCoO0NIVK7DRHt+/E=,tag:NHPBZMl3oN5vx7n6Vi0H2Q==,type:str]",
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
 		"azure_kv": null,
-		"lastmodified": "2019-12-10T22:44:49Z",
-		"mac": "ENC[AES256_GCM,data:wN+npCzfJVz6nwZQ40FTPD23Ly1CEiU1N6aDua+Mgj9cH7NwJOklW8QKTs3+q3f4HEkbeuFE6VQN+Jm05Zsj1inGjAdG2MfDurspJl6Jpe5DBKgk3zudAcc66gm4T4Dn3h7zFvNovOl+VEa4+ntaxIoVNugVDq3ZLTj/wMd3XwU=,iv:RadNg2jPeQEkE1F/GzrdcPIZHbxXoZpo+iOHpRGlLhc=,tag:ID8N4xhN7p3N5EYGTkYKxg==,type:str]",
-		"pgp": [
+		"hc_vault": null,
+		"age": [
 			{
-				"created_at": "2019-12-10T22:44:49Z",
-				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgANOTnicDHAmqwi76yIm2eAgzm32k34hsPS40vKeCKtbIP\niR91/hDmklYXgR9yL9xgBI0SRTMGySSk9YJ9daZd61JVh1IVuxr93Y8GSxhDldAn\n1Wc2dXJ24x7zxfUs4sfZYCtzXZBUb/eAPLDIkeKPzkVKN4kLdVdccOig/2lOuuVo\nw3Xy+m7cx0VPdsFFzVWok15oHj8n0+J8v6Vnyiyx7yI7xgsynNwpZDUN+K15NyGs\nkaO21AeQnxDWmwo4H93+r10esFYns0kyLOCNwN5/XLskT31f9MCo8H4bBDyeO1lE\nrfLKAn0mh81qKedQLTssjElCLBgY4CpcL9B688P/otLgAeSR+v/JrgslAw+QhiBC\nPxqj4ZUC4KbgFeERieC34sjLWuPgxOUoC769iqiM3ArscWLYG6jYb9Acigwtf5/r\nNkFoXHoZPOD15Ne/ElmCDPowh0aAFCwVp6/ipRc0teELTQA=\n=FyYT\n-----END PGP MESSAGE-----",
-				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+				"recipient": "age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqTngrMFh5MHJBd254K1hF\nL0NZOHJua2ozK0tLSTFrWG1oZ21Mai9zRWdRCkdoTVFvK0dKZ2h2SUpJcVRndlNi\nU05GS0s4UWR1Y2RlU3pVREFaR0MwZHcKLS0tIFRmT1FBZzluRmt6SWwzTlJkMWZs\nNm5QVUlrcXhlSEcrZXhmaU9aZFYxRjgKztK1kXVtW/3O8Xuhdzuc+sHjUjCd18AU\nkoepuwtXZJ7IDFMDWsYEosovBa7rVW0IGLS5/Y0eFq5Im2wgHu032Q==\n-----END AGE ENCRYPTED FILE-----\n"
 			},
 			{
-				"created_at": "2019-12-10T22:44:49Z",
-				"enc": "-----BEGIN PGP MESSAGE-----\n\nwYwDXFUltYFwV4MBBACebuDSGC4caG1iSviC+IQKXw/mQXmWDDWLA1RDH7/ZEa/2\nqsA0Eb5bsd4Hf5pW6UpK/TDZpFn3eKeCn8wP2G792Ez19UmhwHB+0Zid9Zq76UAZ\n1bcwX2YJeCgd8/OgIxfh7a6MDDz6TDNGL916BIE6kFJwT3Vvm9EzF7vDglE5mtLg\nAeTK87HB76QLJNDI03Q8JYrN4e1S4KzgxOFhkeAv4lmhR+zgCeU3u0ripltx+Hys\ngtiGJSnuoJrYrwhSIO8JOoc2iR0bkuCn5Gf4VirHEUwrIUqgQVsmLQnick1iv+Hk\n3QA=\n=exjM\n-----END PGP MESSAGE-----",
-				"fp": "D7229043384BCC60326C6FB9D8720D957C3D3074"
+				"recipient": "age1tmaae3ld5vpevmsh5yacsauzx8jetg300mpvc4ugp5zr5l6ssq9sla97ep",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMTndyQmJpQnovK1Q3ODAr\nb01hVWNjZ1g4VEtoUzVDZmhGTXVSVGkydzNZCm9oU3FrUk5jSG40TVA1VzFUa2VY\naWR0ME1melhjd0JNRzlzQUdmMldiS0UKLS0tIDBxZjJDVlhMUmZLUTRSREhIbFlM\nWXpCM1FleVIwbmlyNnJkOTZZNkFYT1EKllNdTjWAUOWcLneY6KOyQ3jYPaPQFaCF\nshRbQt27qewDwX0yQRVAr94oh6dP2koKZCQA0nPX63YFMuYZWyM1BA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
+		"lastmodified": "2022-03-15T22:12:14Z",
+		"mac": "ENC[AES256_GCM,data:ZXiO1bLq+G0MTntftRoxnjWg1AxyCGBKX/DWamIAIMKhf4BmWwU4nVkxFIO3DDdDLAjkBWjkXh/bBdz0g0LnoEGs7UkygJQwltSCRHC+2RuG+3AXZ46ILA80AicU3eV9GlAv/TUz4CCszKKQsN0MRj3jkLIvwfTCAo1ND28YEfo=,iv:6ZXsWS4aV1oTyAiRq0dcflwyKX1ny07DqxcxyyII4jg=,tag:QZLZsYis92RmAGbhUVhMVw==,type:str]",
+		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.5.0"
+		"version": "3.7.1"
 	}
 }

--- a/example.yaml
+++ b/example.yaml
@@ -1,31 +1,31 @@
-myapp1: ENC[AES256_GCM,data:zlGNmhTYX5xol4ZZFsiaoGkD73nn,iv:ql9mkhoU1I64E/FJi3iA0HaAe2U3kQVFee2ZLwPnBik=,tag:SqVSfu/JkRrwqidAT/i0pg==,type:str]
+myapp1: ENC[AES256_GCM,data:KhLDS2R2H/BH32vUit2BGhNONIq8,iv:onHYft9ubwdfdwOOsO9yET9xe6x3UHGl+Ov/LApkCmU=,tag:dzjQG/MOmlGZjMGPhqXIvQ==,type:str]
 app2:
     db:
-        user: ENC[AES256_GCM,data:tQ1l,iv:o9MiMveNYO7T82yDab+4pAt17DO6B4wl8yGy3oFbDb8=,tag:0RjvUUtSQwaUc9SF3RSTZQ==,type:str]
-        password: ENC[AES256_GCM,data:8Ll+TDCgzQ==,iv:aao0OSVdFwaB9EGZ0O+Wn5bRJ6do7hgiQioqiwDi1w0=,tag:WKj0nuSSPkm2dBOBwinYvg==,type:str]
-        #ENC[AES256_GCM,data:uPuUQAahmq1xL5L2B0+a2gHSl7zXucjqa4Kr0AgNKTpgHw3IPx2lCoK+,iv:qYxjRmWMir47YKhmrrHwV0atmGjcJ3Dts+xvQ+6skHQ=,tag:dsj+0DsfiDyJNGUmvZwnHg==,type:comment]
-    key: ENC[AES256_GCM,data:xRjmLiX4BCoSUElToUs5twDq1WNWQNvNMi8yitXly43iGQiwltIs0FsY5u+7fzLepS66oLTGdL0NfWwCGxksYYzUKz5OXRLEatacZP40D71861zu+njmGdXepY0q0q5VOG7ObgIAMMMElVKRIFdjpVgmgUa+/h6R77mEbDztk6lqb28r15XyR6GmdubierTE7aialFzNoC+XO/yk7bnMi0XA/aomj1H5RdZ37LBR2k+rhqXmhkPdGTdJ39t4Ou1Q2Oc4RHRGvgs/EeFqQHcq0AilqXsFIv/PE0bQP564LaOcXK33B+PnoV1D+lXZ7mLOjKlq04c+UojwXjpZeXBr6Ip4H3dAGkPAoQKMtyGwHYzuLCNesxwPv2tPqbxkbVev0AKezGhnPjvCNvRN3S1Y0LPf1atfwzOCBQBhdUTpmXtxCdTNG0cUUZjeIKAyJXDWJooYHlstzDti/dSGMEedOnKq6648Yp7tLNDjAg5CGbDEWjTWehtqgvixUoRdYc2/r/ie3t09XB9h70BzLFDnbNdTNHhg0/aivHeDf8LJ2Co8YvIjLTwlm7GV0mSwzJIoY/2YxXFtw+XFqt+BCt1G8wq3R6OdXZK/+6fUKH/D4EVym5nrGkZIuOCiTB+wpzy09QmZ80Fo+ba0x/1g9ZTMKHk=,iv:ZtzvrO7QSHEOCnKCrIYcaesKnyScV8KaHZr22tUMLlU=,tag:2A3nJBIPF2Q3FlwMYLvG2w==,type:str]
-number: ENC[AES256_GCM,data:DX0qiTOWhQvG/w==,iv:ouWsby8JoFwCRj/mLVCnNcYhP2sdyf4h6nwZuGksE7Q=,tag:lPU6AId2JrlquHnYRw+E8Q==,type:float]
+        user: ENC[AES256_GCM,data:/cSI,iv:v78SLfb75AgxJU6hyorI1NdFIS9BPQhfaYohvnP4+zY=,tag:RT4DZqfxr6acgPTUpYMv0A==,type:str]
+        password: ENC[AES256_GCM,data:DywXZc/D+Q==,iv:O6r4yGD+odLEhDsc0y7aYGb1j/UC83ipBPfiQ69Vvic=,tag:JrZvo0ZQNag1D+nGnwDf1A==,type:str]
+        #ENC[AES256_GCM,data:j8y0qpn+5Yulrb6qZiHpup4brnbQxxB1smcueQB9VtEZX50rDyockNiU,iv:VfbFzTWszoJikA6u7FKj39yCmm2tecC+mV1fVf4bwHs=,tag:cQ4imaD/rK707KWJSa105w==,type:comment]
+    key: ENC[AES256_GCM,data:9h1ykUoMADaC8KWZGkWZcRI0wO40Vhf79lQGxX/fT3rdEXCL5/dkO0cd+ozYBnj6X33JhbLO5qGK3q1QQcAxXdxMKD6MqlOJg42m5ireLp2A0cXvJp0ZYLggDIu8YomEQzfnobudeb2iJ6BUP62K/zDkJJVd9LnSuGK3BUSxx+OPtLg1gDVpp3lVdvGzhdCdTfgS3DECsuB80rTVgBezgSGpFJvOORvNbM5O6Hb3+V1h2QzdkP0dJpaHfDhpUQkiPF7d7qL+6CIzYDK0ZJnX/jp0MWGee5GeRjIdYTkE41l3UKugndKCz6tQW+nJ+B7O1bA/69jPRAXX30RUifpYBPLFACrokwK72VAIp6kyRcv1BKY4nnciuIbWQKxkjMhyzC1EYQQO6fZpI2iOAAMv3vU6yi6x9eQMns0X6ZYoomFJ8CV86pJQAGnubrPRZ8KMHuLm3jasbkae0qvmGNqKkpOD7MBsD3Nnd23XnN84ua4b8LGPXMXf53MaCIYajEsHT9ggsvuHkHZrliAG2WWcQtISpGxvf4QraGuuMPJhHcLT6yjUpB4nttgjhNxUFfushUaYTpESo5p5bE2wC2su7aw/qzY033Ne1Yqm/hoFkIfEDBlWw0nh8XigRvBiBHVeQjDuXBDFrl/u09Px6CUGRSs=,iv:XUT+w2JS3Xe31ZOAYVnifne4RpfHTNJeYW60KSQQcK8=,tag:HLTbzRA8Xnz70WINzbD9sQ==,type:str]
+number: ENC[AES256_GCM,data:ncsT6Jih58uKyg==,iv:UeY6Q0QBhGlfihP5mi/YMOADw58mcZd/Xaz/zwk1TVM=,tag:n5OvH45qiTpJh8IDZ4VzgQ==,type:float]
 an_array:
-- ENC[AES256_GCM,data:vyczE8EQr9qHkaM=,iv:sT5jKk3LZ61Zq/neTli5tcnDFxCxY5RuGr2k5oGQWJQ=,tag:1HgaHWfyh6EJLkI1V2kOrw==,type:str]
-- ENC[AES256_GCM,data:XtBinnYXR7bx1GY=,iv:KvT9smKVmgMNrab+RzfuWscyvJav2r8j1P08ucNmhgQ=,tag:IllAEvIPPeKOfqi1XbmT8w==,type:str]
-- ENC[AES256_GCM,data:gpZ7nwWTGaI+Ti+lk+CPQOoM0ypwK7UMMBUiZAniQHDNJelipqc8hyhNeV+tpJLNaRt74OHs04EX8g==,iv:mKcwVelqLvwVDPjR8NeyMZ7AhsjRgmnYmyEuwPNPrQ8=,tag:vrkoccUfJs105yLCmXYYCw==,type:str]
-- ENC[AES256_GCM,data:L9jPh+7+XsdqEpUnFcD4nA==,iv:xyfKjOXVrBDCIQG5786pSu5yvHdl/PK8eVxkIUWoCIw=,tag:Q0wlTV2e2vZeU6eTF5Oacg==,type:str]
+    - ENC[AES256_GCM,data:Kz5fYNAguRjkRY4=,iv:pmunK+mDtaAZr8inbSIJWBMDPUHp8/YyJjnYJ76RCpo=,tag:K7EtHFPMiQZDbJ73zFIErw==,type:str]
+    - ENC[AES256_GCM,data:nQSYDNgm6hKdvbU=,iv:VyZHyQktkO4fk6ahGL84nWvxkmLBAwosr0eXzlimZOY=,tag:F5lTnici87PZ7zbHyrKTTg==,type:str]
+    - ENC[AES256_GCM,data:Zsnw+CHFZa0QuQFFnJx8QsTt+nnHaPWytgrSbQKqEiGAjAhrgoDAELOIAAwIHL7jDtLNG+ly6q4hiw==,iv:hpYsAWueiwkIevKq8ntuE9NQb3I8GKhQ4/yhjrFfAbE=,tag:WEnlfrvUkvcwvzFVSMwBbg==,type:str]
+    - ENC[AES256_GCM,data:eHFjP2R6JrqZyYjVtWtF8Q==,iv:H0YUug2+5KWAYIt/6X5m9WYH8GXpvJRctn/LPGc6/AI=,tag:xNFY2AzDMY6rOJrtjgyc+g==,type:str]
 somebooleans:
-- ENC[AES256_GCM,data:ExiXxg==,iv:K7FUwomqdA7o9lzvNoAMH/wbXs08FextTGGeJKnaatU=,tag:A9UntgvPIcappmeM3jsbdA==,type:bool]
-- ENC[AES256_GCM,data:3I0AVdM=,iv:q4YKnRIKufREPmwT4sz8plcsOD6iem/tY3NMUV0STBE=,tag:0w4OMKClWTzjKhqsJZT8JA==,type:bool]
+    - ENC[AES256_GCM,data:EQiTQA==,iv:r8Y+bdo0YiWEmY0SrSKrnRcycbGF/1+unE2IEXnYnwg=,tag:IE9M6ZqmfH1QIL9rbZrvVA==,type:bool]
+    - ENC[AES256_GCM,data:rC2PhLw=,iv:OP6EP6FPkwDbjPXocfPJArwknrbuAJM7lrc6tJZ7HqE=,tag:IpR3rYFbxSa9woOZyNuADQ==,type:bool]
 this:
     is:
         a:
             nested:
-                value: ENC[AES256_GCM,data:oFn5fJS5+slb2sCdLY5SxZ+iWeowWtf4wn9g,iv:MZ7i4tZnfCQhQRUwXV2fYQPIJ0tTUFLiD9xuB+765e8=,tag:ZEjE5jvxE5HkN3mma84pKw==,type:str]
-                #ENC[AES256_GCM,data:WwWiKtMsD1shPe5kPHOh2bJqQPGHwxa6GYrR1y14wiid,iv:AZPaRyVDOl100PvBPMeq0lt6/O5ZUhzWX5UmWNABWvM=,tag:PBReK6Ap/VHxncn0G4qtEA==,type:comment]
-                #ENC[AES256_GCM,data:eYRaxgs3vGeS96+ZDV8GYrwbvsrMtnWHOtsT2045tD2mlfOD,iv:/RVNEWuBlxhhY8OlJPbS/81QJukXZu1EWnPUQwrcin4=,tag:DybgrXKGWxoRyIQOlc+UMA==,type:comment]
-                #ENC[AES256_GCM,data:JXKEWGBg4eeCdeQ=,iv:K5keuEjyekf7a3q7WBOKwljsHGXRdQteJcXeeKvHo28=,tag:60VtIdsy13qSKPIEWHUUNg==,type:comment]
+                value: ENC[AES256_GCM,data:m9Q0avRnbiq2b8VeVufjzDs4A4k4HbY1M2Qc,iv:CzLHHTI5BUm4NJ8iVqQhtT1qa+BWQWofsh/LkochIKw=,tag:+jgHNCHj7Dd78lNNbp6Yag==,type:str]
+                #ENC[AES256_GCM,data:Aed5mWaWHCurK8mD1356dBRd4/y0hWLAiWKe+mrjhPxw,iv:C9Ndx3l7Rjj3wgCBjuNiHZ2dIITqdKLvliIsIQ1Syac=,tag:/ymZcErZcdz9bH6ZbYW0+w==,type:comment]
+                #ENC[AES256_GCM,data:Gc+bMiTv73KVRp/A1bNtVU1uHnD1x8qtFBb21HspfoIt2CpL,iv:ehpjR9PLXeU+/YoUUxQWZojs9Hl+XGRlYAiGE006uo4=,tag:bBEdu0qE9lCEhkJr+Mkk4Q==,type:comment]
+                #ENC[AES256_GCM,data:LELzippzGHnQdg4=,iv:3dvWHxOMQ8hRSsdNaR7M7+1/n6ZXkNCyJpN53VVSofA=,tag:+4N8pJgxtJvPoMVdPs6IXQ==,type:comment]
 somelist_unencrypted:
-- all elements of this list
-- remain in clear text
-- because of the _unencrypted suffix in the key
+    - all elements of this list
+    - remain in clear text
+    - because of the _encrypted suffix in the key
 nested_unencrypted:
     this:
         is:
@@ -34,36 +34,28 @@ sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2019-12-10T22:45:53Z'
-    mac: ENC[AES256_GCM,data:WDjMv0eWcyPQzZlr3MppeAMQavN88xv5LzI/9wOlg+WPhRoTdrvgFpWowyWvTdUC/i0ybRQRg2u/Wam0kaqzMDpl/E806Gp9hgJcSneqydDJqPiMh+HpXkXWpc70xbYg8/gc1l7eIfSG7rS1dC2t2je60OAIfC/5zAXrL9KH4Ho=,iv:h0hWhb+46upix6K7hZfNNQoiX7WCapiMTv5I/keZsm4=,tag:v7mVbTN3HWmekol5iaO8FA==,type:str]
-    pgp:
-    -   created_at: '2019-12-10T22:45:53Z'
-        enc: |-
-            -----BEGIN PGP MESSAGE-----
-
-            wcBMAyUpShfNkFB/AQgAE0MaWAQGbTKY7Xg3fDNtzlvnVBkkQRHsLt5kUTu2nAy4
-            sPX0NRXPVF/tAMxr9mI2fRjKnNBXKpOAecNis85D/QEkfflG8/syGkqiJqy9Nqon
-            WSm1bNriPfD4PL850688EJe49Xrsz6rVbW5FYZCHMbnPxvmoheMJRxLonW3/eWPy
-            IjJ9i6Z7W175mv1y7FELOimdQeelynp4r8bOuuq1BhePB4+wJXihw9n0ovuLklpl
-            Kr2iCmIUibSywlEO/LGQT/VXo6R7xgSN2Xg0RwWfflajYHNhVkHlnNYzkACjvdhj
-            ph1M5fLGDqPu+ySSe93EyahNhdwKgQ7R9yF8/13+QdLgAeRmrBgh0N54mQQAQyL7
-            mH/i4SWi4BjgmeHgUeBL4qcm2avg6OUasVJQHlTeA8D+c3TwKSTRVDijN4GBadYJ
-            Z5/vXKOseeBk5JWCnIHC/MtjOkuPt53nvGzi3lYvW+F0FQA=
-            =RDyn
-            -----END PGP MESSAGE-----
-        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
-    -   created_at: '2019-12-10T22:45:53Z'
-        enc: |-
-            -----BEGIN PGP MESSAGE-----
-
-            wYwDXFUltYFwV4MBBABpm+tFhFhv3A7A/L/p6nL3HXKKhONrgguYgXA/hhSg4/bD
-            1Po5pQhCM4yb3gqWewxgVpGNKFr/Gl+kN9eZ3LXp5nEdhei/aQn7BbWkhph5PKt6
-            faiEZAL5PNHvktvEQwPsfNJvxe8QT2Z9oFmlueP0n3mCZz3UV9LZHNwOP7XfzdLg
-            AeRzUGrZK43KavmIjdgPXcd/4ZW14NPgNeGm8+BO4nD26Fvgh+UiCb0TpBiI7WsX
-            HQGUlFjuR6Vd7Q+vg8B/1Ovm3fUw7uCG5Gc2WeB0M+pXaLYS9bCDL9jisGOkD+Ef
-            ZAA=
-            =mqGc
-            -----END PGP MESSAGE-----
-        fp: D7229043384BCC60326C6FB9D8720D957C3D3074
+    hc_vault: []
+    age:
+        - recipient: age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnYU4zaDZ3dFNXTGRLN2Qr
+            ZFdhNGFGUHN2WGxYb1FSNFN6Tk02cHZIMkRnCkVCWXh2NVlTUkRQME9TeGZaaElq
+            eTRieEI1WGdTK1pwL1c1eGtKTDFBUW8KLS0tIFNQeFZSbnJ4QWx3K0wwOFJZODUy
+            SDQ0NDhjcVpYMjYxcm1ZdXFYaWtkakUKWgQTWzf+7rgMjC9rPLSy6jTGbI71hMnC
+            MuRgd5LreYBQo/hRZUYuQ4jmGgOnn3GaUZE1HpSqjjaX8jYn4lNqJA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1tmaae3ld5vpevmsh5yacsauzx8jetg300mpvc4ugp5zr5l6ssq9sla97ep
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhRkUwZ2RKMzZobERMcFdF
+            NGhyNVhlNnNNbUh0NzhMaEgxSlpTL2xRWG4wCkZPdWZsY01HbUUremxBdTRwZ0Nq
+            by85NFZWRTIvazVsZmxIRTByanNUVkEKLS0tIEE0c2h5RHB3c0JHSkhuSU5hTjlM
+            SnJJeGxoQXJ4SlY3d3J4U3Q3cEo2UjQKpI7iyx0ENFxlGnsM7ymneO1YUU5xgo88
+            VRjAc4Tb+mKk+qIeY6rY2AfsKZ8HQsA/CaejRmWT00iXUYj1S5eBww==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2022-03-15T22:11:15Z"
+    mac: ENC[AES256_GCM,data:dwrqrNqt0F0lNkPv/T16GzC57nGmHo/frkdYvsUM/Izfqd7F7t1FUs6sILmz1o6lKllkADL3+A5DISSsaYK05RYr2RuCtZ7V+XC1JKD+loJoo1CAwcHAjGkv/Jv2Y7ePd6tXr6Fb+BuFVQIpwmI5ze3DsKqUd7bQ+DfRRpr9IoA=,iv:9Y2ASpFstcE8ZgwzOvb3oMQsd30Rukd7gvOb7lMvV1o=,tag:qXQosmzw6UoOXFI+8IvtXg==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.5.0
+    version: 3.7.1


### PR DESCRIPTION
In [this](https://github.com/mozilla/sops/pull/966#discussion_r830289256)
comment It was suggested to split the original PR #966 into two.
This change will re-encrypt all example files with age as well in the
hopes to drive age adoption.

This is a follow up to #966