### PR TITLE
Use latest dockerd in CI to allow build alpine image (#870)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.11
       - run:
           name: Build containers
           command: |
@@ -31,7 +32,8 @@ jobs:
             docker build -f Dockerfile.alpine -t mozilla/sops:alpine .
 
   push:
-    machine: true
+    machine:
+      image: ubuntu-2004:202111-02
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
CI failed `make: /bin/sh: Operation not permitted` with after merging #1018.
https://app.circleci.com/pipelines/github/mozilla/sops/135/workflows/9c4d6e8f-f81d-4165-8925-4b69bbe01d41/jobs/438

That's the issue with alpine 3.14 and later: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2
We have to use newer dockerd (20.10.0 or later) to resolve this issue.
