### PR TITLE
keyservice: accept KeyServiceServer in LocalClient

### DIFF
--- a/keyservice/client.go
+++ b/keyservice/client.go
@@ -8,12 +8,18 @@ import (
 
 // LocalClient is a key service client that performs all operations locally
 type LocalClient struct {
-	Server Server
+	Server KeyServiceServer
 }
 
 // NewLocalClient creates a new local client
 func NewLocalClient() LocalClient {
 	return LocalClient{Server{}}
+}
+
+// NewCustomLocalClient creates a new local client with a non-default backing
+// KeyServiceServer implementation
+func NewCustomLocalClient(server KeyServiceServer) LocalClient {
+	return LocalClient{Server: server}
 }
 
 // Decrypt processes a decrypt request locally


### PR DESCRIPTION
This allows for easier injection of your own (local) key service server
implementation, in situations where e.g. you do not want to rely on
environment variables or other runtime defaults.

It is not of impact to end-users, but improves the experience of
developers making use of SOPS as an SDK to e.g. provide decryption
services to users. As they will now in many cases end up copying this
bit of code to make this precise change.

xref: https://github.com/fluxcd/kustomize-controller/blob/v0.22.3/internal/sops/keyservice/client.go#L14-L17