### PR TITLE
Simplify AWS KMS Key ARN regexp

### DIFF
--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -194,7 +194,7 @@ func (key MasterKey) createStsSession(config aws.Config, sess *session.Session) 
 }
 
 func (key MasterKey) createSession() (*session.Session, error) {
-	re := regexp.MustCompile(`^arn:aws[\w-]*:kms:(.+):[0-9]+:(key|alias)/.+$`)
+	re := regexp.MustCompile(`^arn:aws[\w-]*:kms:(.+):\d+:(key|alias)/.+$`)
 	matches := re.FindStringSubmatch(key.Arn)
 	if matches == nil {
 		return nil, fmt.Errorf("No valid ARN found in %q", key.Arn)


### PR DESCRIPTION
The numeric range should replace to any digit.