### PR TITLE
--version without network request

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -552,6 +552,10 @@ func main() {
 			Name:  "rotate, r",
 			Usage: "generate a new data encryption key and reencrypt all values with the new key",
 		},
+		cli.BoolFlag{
+			Name:  "disable-version-check",
+			Usage: "do not check whether the current version is latest during --version",
+		},
 		cli.StringFlag{
 			Name:   "kms, k",
 			Usage:  "comma separated list of KMS ARNs",

--- a/version/version.go
+++ b/version/version.go
@@ -16,18 +16,22 @@ const Version = "3.7.3"
 // PrintVersion handles the version command for sops
 func PrintVersion(c *cli.Context) {
 	out := fmt.Sprintf("%s %s", c.App.Name, c.App.Version)
-	upstreamVersion, err := RetrieveLatestVersionFromUpstream()
-	if err != nil {
-		out += fmt.Sprintf("\n[warning] failed to retrieve latest version from upstream: %v\n", err)
-	}
-	outdated, err := AIsNewerThanB(upstreamVersion, Version)
-	if err != nil {
-		out += fmt.Sprintf("\n[warning] failed to compare current version with latest: %v\n", err)
-	}
-	if outdated {
-		out += fmt.Sprintf("\n[info] sops %s is available, update with `go get -u go.mozilla.org/sops/v3/cmd/sops`\n", upstreamVersion)
+	if c.Bool("disable-version-check") {
+		out += "\n"
 	} else {
-		out += " (latest)\n"
+		upstreamVersion, err := RetrieveLatestVersionFromUpstream()
+		if err != nil {
+			out += fmt.Sprintf("\n[warning] failed to retrieve latest version from upstream: %v\n", err)
+		}
+		outdated, err := AIsNewerThanB(upstreamVersion, Version)
+		if err != nil {
+			out += fmt.Sprintf("\n[warning] failed to compare current version with latest: %v\n", err)
+		}
+		if outdated {
+			out += fmt.Sprintf("\n[info] sops %s is available, update with `go get -u go.mozilla.org/sops/v3/cmd/sops`\n", upstreamVersion)
+		} else {
+			out += " (latest)\n"
+		}
 	}
 	fmt.Fprintf(c.App.Writer, "%s", out)
 }


### PR DESCRIPTION
Adds a new flag `--disable-version-check` which disables the version check (phone home) on `--version`.

I would argue that this behavior should be the default, but for backwards compatibility the other way around is also fine for me. As long as it's possible to turn it off.

Fixes #1100