### PR TITLE
Encrypt in a package and export method encrypt to be used in import "go.mozilla.org/sops/v3/encrypt"

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -28,6 +28,7 @@ import (
 	publishcmd "go.mozilla.org/sops/v3/cmd/sops/subcommand/publish"
 	"go.mozilla.org/sops/v3/cmd/sops/subcommand/updatekeys"
 	"go.mozilla.org/sops/v3/config"
+	"go.mozilla.org/sops/v3/encrypt"
 	"go.mozilla.org/sops/v3/gcpkms"
 	"go.mozilla.org/sops/v3/hcvault"
 	"go.mozilla.org/sops/v3/keys"
@@ -796,7 +797,7 @@ func main() {
 			if err != nil {
 				return toExitError(err)
 			}
-			output, err = encrypt(encryptOpts{
+			output, err = encrypt.Encrypt(encrypt.EncryptOpts{
 				OutputStore:       outputStore,
 				InputStore:        inputStore,
 				InputPath:         fileName,

--- a/encrypt/encrypt.go
+++ b/encrypt/encrypt.go
@@ -1,4 +1,4 @@
-package main
+package encrypt
 
 import (
 	"io/ioutil"
@@ -14,7 +14,7 @@ import (
 	"go.mozilla.org/sops/v3/version"
 )
 
-type encryptOpts struct {
+type EncryptOpts struct {
 	Cipher            sops.Cipher
 	InputStore        sops.Store
 	OutputStore       sops.Store
@@ -46,7 +46,7 @@ func (err *fileAlreadyEncryptedError) UserError() string {
 	return wordwrap.WrapString(message, 75)
 }
 
-func ensureNoMetadata(opts encryptOpts, branch sops.TreeBranch) error {
+func ensureNoMetadata(opts EncryptOpts, branch sops.TreeBranch) error {
 	for _, b := range branch {
 		if b.Key == "sops" {
 			return &fileAlreadyEncryptedError{}
@@ -55,7 +55,7 @@ func ensureNoMetadata(opts encryptOpts, branch sops.TreeBranch) error {
 	return nil
 }
 
-func encrypt(opts encryptOpts) (encryptedFile []byte, err error) {
+func Encrypt(opts EncryptOpts) (encryptedFile []byte, err error) {
 	// Load the file
 	fileBytes, err := ioutil.ReadFile(opts.InputPath)
 	if err != nil {


### PR DESCRIPTION
In Go projects where you need encrypting with sops it'd be nice to have a direct access to the method `func encrypt(opts encryptOpts) (encryptedFile []byte, err error)` in **cmd/sops/encrypt.go**. In that manner you could do something like:
```
import (
...
    "go.mozilla.org/sops/v3/encrypt"
...
)
...
encryptedFile, _ := encrypt.Encrypt(encrypt.EncryptOpts{
                        InputStore:        &yaml.Store{},
                        OutputStore:       &yaml.Store{},
                        InputBytes:        buffer,
                        Cipher:            aes.NewCipher(),
                        KeyServices:       svcs,
                        UnencryptedSuffix: "_unencrypted",
                        EncryptedSuffix:   "",
                        UnencryptedRegex:  "",
                        EncryptedRegex:    "",
                        KeyGroups:         groups,
                        GroupThreshold:    0,
                    })
```